### PR TITLE
dwt2d: fix memory leak in filename malloc

### DIFF
--- a/src/cuda/rodinia/3.1/cuda/dwt2d/main.cu
+++ b/src/cuda/rodinia/3.1/cuda/dwt2d/main.cu
@@ -334,10 +334,12 @@ int main(int argc, char **argv)
     d->dwtLvls  = dwtLvls;
 
     // file names
-    d->srcFilename = (char *)malloc(strlen(argv[0]));
+    // need +1 for \0
+    d->srcFilename = (char *)malloc(strlen(argv[0]) + 1);
     strcpy(d->srcFilename, argv[0]);
-    if (argc == 1) { // only one filename supplyed
-        d->outFilename = (char *)malloc(strlen(d->srcFilename)+4);
+    if (argc == 1) { // only one filename supplied
+        // need +1 for \0
+        d->outFilename = (char *)malloc(strlen(d->srcFilename)+1+4);
         strcpy(d->outFilename, d->srcFilename);
         strcpy(d->outFilename+strlen(d->srcFilename), ".dwt");
     } else {

--- a/src/cuda/rodinia/3.1/cuda/particlefilter/ex_particle_CUDA_float_seq.cu
+++ b/src/cuda/rodinia/3.1/cuda/particlefilter/ex_particle_CUDA_float_seq.cu
@@ -739,7 +739,7 @@ void particleFilter(unsigned char * I, int IszX, int IszY, int Nfr, int * seed, 
     }//end loop
 
     //block till kernels are finished
-    cudaThreadSynchronize();
+    cudaDeviceSynchronize();
     long long back_time = get_time();
 
     cudaFree(xj_GPU);

--- a/src/cuda/rodinia/3.1/cuda/particlefilter/ex_particle_CUDA_float_seq.cu
+++ b/src/cuda/rodinia/3.1/cuda/particlefilter/ex_particle_CUDA_float_seq.cu
@@ -55,8 +55,7 @@ void check_error(cudaError e) {
 
 void cuda_print_double_array(double *array_GPU, size_t size) {
     //allocate temporary array for printing
-    double* mem = (double*) malloc(sizeof (double) *size);
-
+    double* mem = (double*)calloc(size, sizeof (double));
     //transfer data from device
     cudaMemcpy(mem, array_GPU, sizeof (double) *size, cudaMemcpyDeviceToHost);
 
@@ -577,7 +576,7 @@ void videoSequence(unsigned char * I, int IszX, int IszY, int Nfr, int * seed) {
     }
 
     /*dilate matrix*/
-    unsigned char * newMatrix = (unsigned char *) malloc(sizeof (unsigned char) * IszX * IszY * Nfr);
+    unsigned char * newMatrix = (unsigned char *)calloc(IszX * IszY * Nfr, sizeof (unsigned char));
     imdilate_disk(I, IszX, IszY, Nfr, 5, newMatrix);
     int x, y;
     for (x = 0; x < IszX; x++) {
@@ -640,7 +639,7 @@ void particleFilter(unsigned char * I, int IszX, int IszY, int Nfr, int * seed, 
     //expected object locations, compared to center
     int radius = 5;
     int diameter = radius * 2 - 1;
-    int * disk = (int*) malloc(diameter * diameter * sizeof (int));
+    int * disk = (int*)calloc(diameter * diameter, sizeof(int));
     strelDisk(disk, radius);
     int countOnes = 0;
     int x, y;
@@ -650,21 +649,21 @@ void particleFilter(unsigned char * I, int IszX, int IszY, int Nfr, int * seed, 
                 countOnes++;
         }
     }
-    int * objxy = (int *) malloc(countOnes * 2 * sizeof (int));
+    int * objxy = (int *)calloc(countOnes * 2, sizeof(int));
     getneighbors(disk, countOnes, objxy, radius);
     //initial weights are all equal (1/Nparticles)
-    double * weights = (double *) malloc(sizeof (double) *Nparticles);
+    double * weights = (double *)calloc(Nparticles, sizeof(double));
     for (x = 0; x < Nparticles; x++) {
         weights[x] = 1 / ((double) (Nparticles));
     }
 
     //initial likelihood to 0.0
-    double * likelihood = (double *) malloc(sizeof (double) *Nparticles);
-    double * arrayX = (double *) malloc(sizeof (double) *Nparticles);
-    double * arrayY = (double *) malloc(sizeof (double) *Nparticles);
-    double * xj = (double *) malloc(sizeof (double) *Nparticles);
-    double * yj = (double *) malloc(sizeof (double) *Nparticles);
-    double * CDF = (double *) malloc(sizeof (double) *Nparticles);
+    double * likelihood = (double *)calloc(Nparticles, sizeof (double));
+    double * arrayX = (double *)calloc(Nparticles, sizeof(double));
+    double * arrayY = (double *)calloc(Nparticles, sizeof(double));
+    double * xj = (double *)calloc(Nparticles, sizeof(double));
+    double * yj = (double *)calloc(Nparticles, sizeof(double));
+    double * CDF = (double *)calloc(Nparticles, sizeof(double));
 
     //GPU copies of arrays
     double * arrayX_GPU;
@@ -677,9 +676,9 @@ void particleFilter(unsigned char * I, int IszX, int IszY, int Nfr, int * seed, 
     double * weights_GPU;
     int * objxy_GPU;
 
-    int * ind = (int*) malloc(sizeof (int) *countOnes * Nparticles);
+    int * ind = (int *)calloc(countOnes * Nparticles, sizeof(int));
     int * ind_GPU;
-    double * u = (double *) malloc(sizeof (double) *Nparticles);
+    double * u = (double *)calloc(Nparticles, sizeof(double));
     double * u_GPU;
     int * seed_GPU;
     double* partial_sums;
@@ -786,6 +785,9 @@ void particleFilter(unsigned char * I, int IszX, int IszY, int Nfr, int * seed, 
     cudaFree(arrayX_GPU);
 
     //free regular memory
+    free(disk);
+    free(objxy);
+    free(weights);
     free(likelihood);
     free(arrayX);
     free(arrayY);
@@ -856,12 +858,12 @@ int main(int argc, char * argv[]) {
         return 0;
     }
     //establish seed
-    int * seed = (int *) malloc(sizeof (int) *Nparticles);
+    int * seed = (int *)calloc(Nparticles, sizeof(int));
     int i;
     for (i = 0; i < Nparticles; i++)
         seed[i] = time(0) * i;
     //malloc matrix
-    unsigned char * I = (unsigned char *) malloc(sizeof (unsigned char) *IszX * IszY * Nfr);
+    unsigned char * I = (unsigned char *)calloc(IszX * IszY * Nfr, sizeof(unsigned char));
     long long start = get_time();
     //call video sequence
     videoSequence(I, IszX, IszY, Nfr, seed);

--- a/src/cuda/rodinia/3.1/cuda/particlefilter/ex_particle_CUDA_float_seq.cu
+++ b/src/cuda/rodinia/3.1/cuda/particlefilter/ex_particle_CUDA_float_seq.cu
@@ -63,7 +63,7 @@ void cuda_print_double_array(double *array_GPU, size_t size) {
     printf("PRINTING ARRAY VALUES\n");
     //print values in memory
     for (size_t i = 0; i < size; ++i) {
-        printf("[%d]:%0.6f\n", i, mem[i]);
+        printf("[%ld]:%0.6f\n", i, mem[i]);
     }
     printf("FINISHED PRINTING ARRAY VALUES\n");
 

--- a/src/cuda/rodinia/3.1/cuda/particlefilter/ex_particle_CUDA_naive_seq.cu
+++ b/src/cuda/rodinia/3.1/cuda/particlefilter/ex_particle_CUDA_naive_seq.cu
@@ -569,7 +569,7 @@ void particleFilter(int * I, int IszX, int IszY, int Nfr, int * seed, int Nparti
 		
 		//KERNEL FUNCTION CALL
 		kernel <<< num_blocks, threads_per_block >>> (arrayX_GPU, arrayY_GPU, CDF_GPU, u_GPU, xj_GPU, yj_GPU, Nparticles);
-                cudaThreadSynchronize();
+                cudaDeviceSynchronize();
                 long long start_copy_back = get_time();
 		//CUDA memory copying back from GPU to CPU memory
 		cudaMemcpy(yj, yj_GPU, sizeof(double)*Nparticles, cudaMemcpyDeviceToHost);

--- a/src/cuda/rodinia/3.1/cuda/particlefilter/ex_particle_CUDA_naive_seq.cu
+++ b/src/cuda/rodinia/3.1/cuda/particlefilter/ex_particle_CUDA_naive_seq.cu
@@ -36,69 +36,69 @@ const int threads_per_block = 128;
 *returns a long int representing the time
 *****************************/
 long long get_time() {
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-	return (tv.tv_sec * 1000000) + tv.tv_usec;
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  return (tv.tv_sec * 1000000) + tv.tv_usec;
 }
 // Returns the number of seconds elapsed between the two specified times
 float elapsed_time(long long start_time, long long end_time) {
-        return (float) (end_time - start_time) / (1000 * 1000);
+  return (float) (end_time - start_time) / (1000 * 1000);
 }
 /*****************************
-* CHECK_ERROR
-* Checks for CUDA errors and prints them to the screen to help with
-* debugging of CUDA related programming
-*****************************/
+ * CHECK_ERROR
+ * Checks for CUDA errors and prints them to the screen to help with
+ * debugging of CUDA related programming
+ *****************************/
 void check_error(cudaError e) {
-     if (e != cudaSuccess) {
-     	printf("\nCUDA error: %s\n", cudaGetErrorString(e));
-	    exit(1);
-     }
+  if (e != cudaSuccess) {
+    printf("\nCUDA error: %s\n", cudaGetErrorString(e));
+    exit(1);
+  }
 }
 __device__ int findIndexSeq(double * CDF, int lengthCDF, double value)
 {
-	int index = -1;
-	int x;
-	for(x = 0; x < lengthCDF; x++)
-	{
-		if(CDF[x] >= value)
-		{
-			index = x;
-			break;
-		}
-	}
-	if(index == -1)
-		return lengthCDF-1;
-	return index;
+  int index = -1;
+  int x;
+  for(x = 0; x < lengthCDF; x++)
+  {
+    if(CDF[x] >= value)
+    {
+      index = x;
+      break;
+    }
+  }
+  if(index == -1)
+    return lengthCDF-1;
+  return index;
 }
 __device__ int findIndexBin(double * CDF, int beginIndex, int endIndex, double value)
 {
-	if(endIndex < beginIndex)
-		return -1;
-	int middleIndex;
-	while(endIndex > beginIndex)
-	{
-		middleIndex = beginIndex + ((endIndex-beginIndex)/2);
-		if(CDF[middleIndex] >= value)
-		{
-			if(middleIndex == 0)
-				return middleIndex;
-			else if(CDF[middleIndex-1] < value)
-				return middleIndex;
-			else if(CDF[middleIndex-1] == value)
-			{
-				while(CDF[middleIndex] == value && middleIndex >= 0)
-					middleIndex--;
-				middleIndex++;
-				return middleIndex;
-			}
-		}
-		if(CDF[middleIndex] > value)
-			endIndex = middleIndex-1;
-		else
-			beginIndex = middleIndex+1;
-	}
-	return -1;
+  if(endIndex < beginIndex)
+    return -1;
+  int middleIndex;
+  while(endIndex > beginIndex)
+  {
+    middleIndex = beginIndex + ((endIndex-beginIndex)/2);
+    if(CDF[middleIndex] >= value)
+    {
+      if(middleIndex == 0)
+        return middleIndex;
+      else if(CDF[middleIndex-1] < value)
+        return middleIndex;
+      else if(CDF[middleIndex-1] == value)
+      {
+        while(CDF[middleIndex] == value && middleIndex >= 0)
+          middleIndex--;
+        middleIndex++;
+        return middleIndex;
+      }
+    }
+    if(CDF[middleIndex] > value)
+      endIndex = middleIndex-1;
+    else
+      beginIndex = middleIndex+1;
+  }
+  return -1;
 }
 /*****************************
 * CUDA Kernel Function to replace FindIndex
@@ -111,39 +111,37 @@ __device__ int findIndexBin(double * CDF, int beginIndex, int endIndex, double v
 * param7: Nparticles
 *****************************/
 __global__ void kernel(double * arrayX, double * arrayY, double * CDF, double * u, double * xj, double * yj, int Nparticles){
-	int block_id = blockIdx.x;// + gridDim.x * blockIdx.y;
-	int i = blockDim.x * block_id + threadIdx.x;
-	
-	if(i < Nparticles){
-	
-		int index = -1;
-		int x;
-		
-		for(x = 0; x < Nparticles; x++){
-			if(CDF[x] >= u[i]){
-				index = x;
-				break;
-			}
-		}
-		if(index == -1){
-			index = Nparticles-1;
-		}
-		
-		xj[i] = arrayX[index];
-		yj[i] = arrayY[index];
-		
-	}
+  int block_id = blockIdx.x;// + gridDim.x * blockIdx.y;
+  int i = blockDim.x * block_id + threadIdx.x;
+
+  if(i < Nparticles){
+    int index = -1;
+    int x;
+
+    for(x = 0; x < Nparticles; x++){
+      if(CDF[x] >= u[i]){
+        index = x;
+        break;
+      }
+    }
+    if(index == -1){
+      index = Nparticles-1;
+    }
+
+    xj[i] = arrayX[index];
+    yj[i] = arrayY[index];
+  }
 }
 /** 
-* Takes in a double and returns an integer that approximates to that double
-* @return if the mantissa < .5 => return value < input value; else return value > input value
-*/
+ * Takes in a double and returns an integer that approximates to that double
+ * @return if the mantissa < .5 => return value < input value; else return value > input value
+ */
 double roundDouble(double value){
-	int newValue = (int)(value);
-	if(value - newValue < .5)
-	return newValue;
-	else
-	return newValue++;
+  int newValue = (int)(value);
+  if(value - newValue < .5)
+    return newValue;
+  else
+    return newValue++;
 }
 /**
 * Set values of the 3D array to a newValue if that value is equal to the testValue
@@ -155,15 +153,15 @@ double roundDouble(double value){
 * @param dimZ The number of frames
 */
 void setIf(int testValue, int newValue, int * array3D, int * dimX, int * dimY, int * dimZ){
-	int x, y, z;
-	for(x = 0; x < *dimX; x++){
-		for(y = 0; y < *dimY; y++){
-			for(z = 0; z < *dimZ; z++){
-				if(array3D[x * *dimY * *dimZ+y * *dimZ + z] == testValue)
-				array3D[x * *dimY * *dimZ + y * *dimZ + z] = newValue;
-			}
-		}
-	}
+  int x, y, z;
+  for(x = 0; x < *dimX; x++){
+    for(y = 0; y < *dimY; y++){
+      for(z = 0; z < *dimZ; z++){
+        if(array3D[x * *dimY * *dimZ+y * *dimZ + z] == testValue)
+          array3D[x * *dimY * *dimZ + y * *dimZ + z] = newValue;
+      }
+    }
+  }
 }
 /**
 * Generates a uniformly distributed random number using the provided seed and GCC's settings for the Linear Congruential Generator (LCG)
@@ -175,9 +173,9 @@ void setIf(int testValue, int newValue, int * array3D, int * dimX, int * dimY, i
 */
 double randu(int * seed, int index)
 {
-	int num = A*seed[index] + C;
-	seed[index] = num % M;
-	return fabs(seed[index]/((double) M));
+  int num = A*seed[index] + C;
+  seed[index] = num % M;
+  return fabs(seed[index]/((double) M));
 }
 /**
 * Generates a normally distributed random number using the Box-Muller transformation
@@ -188,12 +186,12 @@ double randu(int * seed, int index)
 * @see http://en.wikipedia.org/wiki/Normal_distribution, section computing value for normal random distribution
 */
 double randn(int * seed, int index){
-	/*Box-Muller algorithm*/
-	double u = randu(seed, index);
-	double v = randu(seed, index);
-	double cosine = cos(2*PI*v);
-	double rt = -2*log(u);
-	return sqrt(rt)*cosine;
+  /*Box-Muller algorithm*/
+  double u = randu(seed, index);
+  double v = randu(seed, index);
+  double cosine = cos(2*PI*v);
+  double rt = -2*log(u);
+  return sqrt(rt)*cosine;
 }
 /**
 * Sets values of 3D matrix using randomly generated numbers from a normal distribution
@@ -204,14 +202,14 @@ double randn(int * seed, int index){
 * @param seed The seed array
 */
 void addNoise(int * array3D, int * dimX, int * dimY, int * dimZ, int * seed){
-	int x, y, z;
-	for(x = 0; x < *dimX; x++){
-		for(y = 0; y < *dimY; y++){
-			for(z = 0; z < *dimZ; z++){
-				array3D[x * *dimY * *dimZ + y * *dimZ + z] = array3D[x * *dimY * *dimZ + y * *dimZ + z] + (int)(5*randn(seed, 0));
-			}
-		}
-	}
+  int x, y, z;
+  for(x = 0; x < *dimX; x++){
+    for(y = 0; y < *dimY; y++){
+      for(z = 0; z < *dimZ; z++){
+        array3D[x * *dimY * *dimZ + y * *dimZ + z] = array3D[x * *dimY * *dimZ + y * *dimZ + z] + (int)(5*randn(seed, 0));
+      }
+    }
+  }
 }
 /**
 * Fills a radius x radius matrix representing the disk
@@ -220,15 +218,15 @@ void addNoise(int * array3D, int * dimX, int * dimY, int * dimZ, int * seed){
 */
 void strelDisk(int * disk, int radius)
 {
-	int diameter = radius*2 - 1;
-	int x, y;
-	for(x = 0; x < diameter; x++){
-		for(y = 0; y < diameter; y++){
-			double distance = sqrt(pow((double)(x-radius+1),2) + pow((double)(y-radius+1),2));
-			if(distance < radius)
-			disk[x*diameter + y] = 1;
-		}
-	}
+  int diameter = radius*2 - 1;
+  int x, y;
+  for(x = 0; x < diameter; x++){
+    for(y = 0; y < diameter; y++){
+      double distance = sqrt(pow((double)(x-radius+1),2) + pow((double)(y-radius+1),2));
+      if(distance < radius)
+        disk[x*diameter + y] = 1;
+    }
+  }
 }
 /**
 * Dilates the provided video
@@ -243,26 +241,26 @@ void strelDisk(int * disk, int radius)
 */
 void dilate_matrix(int * matrix, int posX, int posY, int posZ, int dimX, int dimY, int dimZ, int error)
 {
-	int startX = posX - error;
-	while(startX < 0)
-	startX++;
-	int startY = posY - error;
-	while(startY < 0)
-	startY++;
-	int endX = posX + error;
-	while(endX > dimX)
-	endX--;
-	int endY = posY + error;
-	while(endY > dimY)
-	endY--;
-	int x,y;
-	for(x = startX; x < endX; x++){
-		for(y = startY; y < endY; y++){
-			double distance = sqrt( pow((double)(x-posX),2) + pow((double)(y-posY),2) );
-			if(distance < error)
-			matrix[x*dimY*dimZ + y*dimZ + posZ] = 1;
-		}
-	}
+  int startX = posX - error;
+  while(startX < 0)
+    startX++;
+  int startY = posY - error;
+  while(startY < 0)
+    startY++;
+  int endX = posX + error;
+  while(endX > dimX)
+    endX--;
+  int endY = posY + error;
+  while(endY > dimY)
+    endY--;
+  int x,y;
+  for(x = startX; x < endX; x++){
+    for(y = startY; y < endY; y++){
+      double distance = sqrt( pow((double)(x-posX),2) + pow((double)(y-posY),2) );
+      if(distance < error)
+        matrix[x*dimY*dimZ + y*dimZ + posZ] = 1;
+    }
+  }
 }
 
 /**
@@ -276,16 +274,16 @@ void dilate_matrix(int * matrix, int posX, int posY, int posZ, int dimX, int dim
 */
 void imdilate_disk(int * matrix, int dimX, int dimY, int dimZ, int error, int * newMatrix)
 {
-	int x, y, z;
-	for(z = 0; z < dimZ; z++){
-		for(x = 0; x < dimX; x++){
-			for(y = 0; y < dimY; y++){
-				if(matrix[x*dimY*dimZ + y*dimZ + z] == 1){
-					dilate_matrix(newMatrix, x, y, z, dimX, dimY, dimZ, error);
-				}
-			}
-		}
-	}
+  int x, y, z;
+  for(z = 0; z < dimZ; z++){
+    for(x = 0; x < dimX; x++){
+      for(y = 0; y < dimY; y++){
+        if(matrix[x*dimY*dimZ + y*dimZ + z] == 1){
+          dilate_matrix(newMatrix, x, y, z, dimX, dimY, dimZ, error);
+        }
+      }
+    }
+  }
 }
 /**
 * Fills a 2D array describing the offsets of the disk object
@@ -295,19 +293,19 @@ void imdilate_disk(int * matrix, int dimX, int dimY, int dimZ, int error, int * 
 * @param radius The radius used for dilation
 */
 void getneighbors(int * se, int numOnes, double * neighbors, int radius){
-	int x, y;
-	int neighY = 0;
-	int center = radius - 1;
-	int diameter = radius*2 -1;
-	for(x = 0; x < diameter; x++){
-		for(y = 0; y < diameter; y++){
-			if(se[x*diameter + y]){
-				neighbors[neighY*2] = (int)(y - center);
-				neighbors[neighY*2 + 1] = (int)(x - center);
-				neighY++;
-			}
-		}
-	}
+  int x, y;
+  int neighY = 0;
+  int center = radius - 1;
+  int diameter = radius*2 -1;
+  for(x = 0; x < diameter; x++){
+    for(y = 0; y < diameter; y++){
+      if(se[x*diameter + y]){
+        neighbors[neighY*2] = (int)(y - center);
+        neighbors[neighY*2 + 1] = (int)(x - center);
+        neighY++;
+      }
+    }
+  }
 }
 /**
 * The synthetic video sequence we will work with here is composed of a
@@ -322,42 +320,42 @@ void getneighbors(int * se, int numOnes, double * neighbors, int radius){
 * @param seed The seed array used for number generation
 */
 void videoSequence(int * I, int IszX, int IszY, int Nfr, int * seed){
-	int k;
-	int max_size = IszX*IszY*Nfr;
-	/*get object centers*/
-	int x0 = (int)roundDouble(IszY/2.0);
-	int y0 = (int)roundDouble(IszX/2.0);
-	I[x0 *IszY *Nfr + y0 * Nfr  + 0] = 1;
-	
-	/*move point*/
-	int xk, yk, pos;
-	for(k = 1; k < Nfr; k++){
-		xk = abs(x0 + (k-1));
-		yk = abs(y0 - 2*(k-1));
-		pos = yk * IszY * Nfr + xk *Nfr + k;
-		if(pos >= max_size)
-		pos = 0;
-		I[pos] = 1;
-	}
-	
-	/*dilate matrix*/
-	int * newMatrix = (int *)calloc(IszX*IszY*Nfr, sizeof(int));
-	imdilate_disk(I, IszX, IszY, Nfr, 5, newMatrix);
-	int x, y;
-	for(x = 0; x < IszX; x++){
-		for(y = 0; y < IszY; y++){
-			for(k = 0; k < Nfr; k++){
-				I[x*IszY*Nfr + y*Nfr + k] = newMatrix[x*IszY*Nfr + y*Nfr + k];
-			}
-		}
-	}
-	free(newMatrix);
-	
-	/*define background, add noise*/
-	setIf(0, 100, I, &IszX, &IszY, &Nfr);
-	setIf(1, 228, I, &IszX, &IszY, &Nfr);
-	/*add noise*/
-	addNoise(I, &IszX, &IszY, &Nfr, seed);
+  int k;
+  int max_size = IszX*IszY*Nfr;
+  /*get object centers*/
+  int x0 = (int)roundDouble(IszY/2.0);
+  int y0 = (int)roundDouble(IszX/2.0);
+  I[x0 *IszY *Nfr + y0 * Nfr  + 0] = 1;
+
+  /*move point*/
+  int xk, yk, pos;
+  for(k = 1; k < Nfr; k++){
+    xk = abs(x0 + (k-1));
+    yk = abs(y0 - 2*(k-1));
+    pos = yk * IszY * Nfr + xk *Nfr + k;
+    if(pos >= max_size)
+      pos = 0;
+    I[pos] = 1;
+  }
+
+  /*dilate matrix*/
+  int * newMatrix = (int *)calloc(IszX*IszY*Nfr, sizeof(int));
+  imdilate_disk(I, IszX, IszY, Nfr, 5, newMatrix);
+  int x, y;
+  for(x = 0; x < IszX; x++){
+    for(y = 0; y < IszY; y++){
+      for(k = 0; k < Nfr; k++){
+        I[x*IszY*Nfr + y*Nfr + k] = newMatrix[x*IszY*Nfr + y*Nfr + k];
+      }
+    }
+  }
+  free(newMatrix);
+
+  /*define background, add noise*/
+  setIf(0, 100, I, &IszX, &IszY, &Nfr);
+  setIf(1, 228, I, &IszX, &IszY, &Nfr);
+  /*add noise*/
+  addNoise(I, &IszX, &IszY, &Nfr, seed);
 }
 /**
 * Determines the likelihood sum based on the formula: SUM( (IK[IND] - 100)^2 - (IK[IND] - 228)^2)/ 100
@@ -367,33 +365,33 @@ void videoSequence(int * I, int IszX, int IszY, int Nfr, int * seed){
 * @return A double representing the sum
 */
 double calcLikelihoodSum(int * I, int * ind, int numOnes){
-	double likelihoodSum = 0.0;
-	int y;
-	for(y = 0; y < numOnes; y++)
-	likelihoodSum += (pow((double)(I[ind[y]] - 100),2) - pow((double)(I[ind[y]]-228),2))/50.0;
-	return likelihoodSum;
+  double likelihoodSum = 0.0;
+  int y;
+  for(y = 0; y < numOnes; y++)
+    likelihoodSum += (pow((double)(I[ind[y]] - 100),2) - pow((double)(I[ind[y]]-228),2))/50.0;
+  return likelihoodSum;
 }
 /**
-* Finds the first element in the CDF that is greater than or equal to the provided value and returns that index
-* @note This function uses sequential search
-* @param CDF The CDF
-* @param lengthCDF The length of CDF
-* @param value The value to be found
-* @return The index of value in the CDF; if value is never found, returns the last index
-*/
+ * Finds the first element in the CDF that is greater than or equal to the provided value and returns that index
+ * @note This function uses sequential search
+ * @param CDF The CDF
+ * @param lengthCDF The length of CDF
+ * @param value The value to be found
+ * @return The index of value in the CDF; if value is never found, returns the last index
+ */
 int findIndex(double * CDF, int lengthCDF, double value){
-	int index = -1;
-	int x;
-	for(x = 0; x < lengthCDF; x++){
-		if(CDF[x] >= value){
-			index = x;
-			break;
-		}
-	}
-	if(index == -1){
-		return lengthCDF-1;
-	}
-	return index;
+  int index = -1;
+  int x;
+  for(x = 0; x < lengthCDF; x++){
+    if(CDF[x] >= value){
+      index = x;
+      break;
+    }
+  }
+  if(index == -1){
+    return lengthCDF-1;
+  }
+  return index;
 }
 /**
 * The implementation of the particle filter using OpenMP for many frames
@@ -407,290 +405,288 @@ int findIndex(double * CDF, int lengthCDF, double value){
 * @param Nparticles The number of particles to be used
 */
 void particleFilter(int * I, int IszX, int IszY, int Nfr, int * seed, int Nparticles){
-	int max_size = IszX*IszY*Nfr;
-	long long start = get_time();
-	//original particle centroid
-	double xe = roundDouble(IszY/2.0);
-	double ye = roundDouble(IszX/2.0);
-	
-	//expected object locations, compared to center
-	int radius = 5;
-	int diameter = radius*2 - 1;
-	int * disk = (int *)calloc(diameter*diameter, sizeof(int));
-	strelDisk(disk, radius);
-	int countOnes = 0;
-	int x, y;
-	for(x = 0; x < diameter; x++){
-		for(y = 0; y < diameter; y++){
-			if(disk[x*diameter + y] == 1)
-				countOnes++;
-		}
-	}
-	double * objxy = (double *))calloc(countOnes*2, sizeof(double));
-	getneighbors(disk, countOnes, objxy, radius);
-	
-	long long get_neighbors = get_time();
-	printf("TIME TO GET NEIGHBORS TOOK: %f\n", elapsed_time(start, get_neighbors));
-	//initial weights are all equal (1/Nparticles)
-	double * weights = (double *)calloc(Nparticles, sizeof(double));
-	for(x = 0; x < Nparticles; x++){
-		weights[x] = 1/((double)(Nparticles));
-	}
-	long long get_weights = get_time();
-	printf("TIME TO GET WEIGHTSTOOK: %f\n", elapsed_time(get_neighbors, get_weights));
-	//initial likelihood to 0.0
-	double * likelihood = (double *)calloc(Nparticles, sizeof(double);
-	double * arrayX = (double *)calloc(Nparticles, sizeof(double);
-	double * arrayY = (double *)calloc(Nparticles, sizeof(double);
-	double * xj = (double *)calloc(Nparticles, sizeof(double);
-	double * yj = (double *)calloc(Nparticles, sizeof(double);
-	double * CDF = (double *)calloc(Nparticles, sizeof(double);
-	
-	//GPU copies of arrays
-	double * arrayX_GPU;
-	double * arrayY_GPU;
-	double * xj_GPU;
-	double * yj_GPU;
-	double * CDF_GPU;
-	
-	int * ind = (int *)calloc(countOnes, sizeof(int));
-	double * u = (double *)calloc(Nparticles, sizeof(double);
-	double * u_GPU;
-	
-	//CUDA memory allocation
-	check_error(cudaMalloc((void **) &arrayX_GPU, sizeof(double)*Nparticles));
-	check_error(cudaMalloc((void **) &arrayY_GPU, sizeof(double)*Nparticles));
-	check_error(cudaMalloc((void **) &xj_GPU, sizeof(double)*Nparticles));
-	check_error(cudaMalloc((void **) &yj_GPU, sizeof(double)*Nparticles));
-	check_error(cudaMalloc((void **) &CDF_GPU, sizeof(double)*Nparticles));
-	check_error(cudaMalloc((void **) &u_GPU, sizeof(double)*Nparticles));
-	
-	for(x = 0; x < Nparticles; x++){
-		arrayX[x] = xe;
-		arrayY[x] = ye;
-	}
-	int k;
-	//double * Ik = (double *)calloc(IszX*IszY, sizeof(double));
-	int indX, indY;
-	for(k = 1; k < Nfr; k++){
-		long long set_arrays = get_time();
-		//printf("TIME TO SET ARRAYS TOOK: %f\n", elapsed_time(get_weights, set_arrays));
-		//apply motion model
-		//draws sample from motion model (random walk). The only prior information
-		//is that the object moves 2x as fast as in the y direction
-		
-		for(x = 0; x < Nparticles; x++){
-			arrayX[x] = arrayX[x] + 1.0 + 5.0*randn(seed, x);
-			arrayY[x] = arrayY[x] - 2.0 + 2.0*randn(seed, x);
-		}
-		//particle filter likelihood
-		long long error = get_time();
-		printf("TIME TO SET ERROR TOOK: %f\n", elapsed_time(set_arrays, error));
-		for(x = 0; x < Nparticles; x++){
-		
-			//compute the likelihood: remember our assumption is that you know
-			// foreground and the background image intensity distribution.
-			// Notice that we consider here a likelihood ratio, instead of
-			// p(z|x). It is possible in this case. why? a hometask for you.		
-			//calc ind
-			for(y = 0; y < countOnes; y++){
-				indX = roundDouble(arrayX[x]) + objxy[y*2 + 1];
-				indY = roundDouble(arrayY[x]) + objxy[y*2];
-				ind[y] = fabs(indX*IszY*Nfr + indY*Nfr + k);
-				if(ind[y] >= max_size)
-					ind[y] = 0;
-			}
-			likelihood[x] = calcLikelihoodSum(I, ind, countOnes);
-			likelihood[x] = likelihood[x]/countOnes;
-		}
-		long long likelihood_time = get_time();
-		printf("TIME TO GET LIKELIHOODS TOOK: %f\n", elapsed_time(error, likelihood_time));
-		// update & normalize weights
-		// using equation (63) of Arulampalam Tutorial		
-		for(x = 0; x < Nparticles; x++){
-			weights[x] = weights[x] * exp(likelihood[x]);
-		}
-		long long exponential = get_time();
-		printf("TIME TO GET EXP TOOK: %f\n", elapsed_time(likelihood_time, exponential));
-		double sumWeights = 0;	
-		for(x = 0; x < Nparticles; x++){
-			sumWeights += weights[x];
-		}
-		long long sum_time = get_time();
-		printf("TIME TO SUM WEIGHTS TOOK: %f\n", elapsed_time(exponential, sum_time));
-		for(x = 0; x < Nparticles; x++){
-				weights[x] = weights[x]/sumWeights;
-		}
-		long long normalize = get_time();
-		printf("TIME TO NORMALIZE WEIGHTS TOOK: %f\n", elapsed_time(sum_time, normalize));
-		xe = 0;
-		ye = 0;
-		// estimate the object location by expected values
-		for(x = 0; x < Nparticles; x++){
-			xe += arrayX[x] * weights[x];
-			ye += arrayY[x] * weights[x];
-		}
-		long long move_time = get_time();
-		printf("TIME TO MOVE OBJECT TOOK: %f\n", elapsed_time(normalize, move_time));
-		printf("XE: %lf\n", xe);
-		printf("YE: %lf\n", ye);
-		double distance = sqrt( pow((double)(xe-(int)roundDouble(IszY/2.0)),2) + pow((double)(ye-(int)roundDouble(IszX/2.0)),2) );
-		printf("%lf\n", distance);
-		//display(hold off for now)
-		
-		//pause(hold off for now)
-		
-		//resampling
-		
-		
-		CDF[0] = weights[0];
-		for(x = 1; x < Nparticles; x++){
-			CDF[x] = weights[x] + CDF[x-1];
-		}
-		long long cum_sum = get_time();
-		printf("TIME TO CALC CUM SUM TOOK: %f\n", elapsed_time(move_time, cum_sum));
-		double u1 = (1/((double)(Nparticles)))*randu(seed, 0);
-		for(x = 0; x < Nparticles; x++){
-			u[x] = u1 + x/((double)(Nparticles));
-		}
-		long long u_time = get_time();
-		printf("TIME TO CALC U TOOK: %f\n", elapsed_time(cum_sum, u_time));
-		long long start_copy = get_time();
-		//CUDA memory copying from CPU memory to GPU memory
-		cudaMemcpy(arrayX_GPU, arrayX, sizeof(double)*Nparticles, cudaMemcpyHostToDevice);
-		cudaMemcpy(arrayY_GPU, arrayY, sizeof(double)*Nparticles, cudaMemcpyHostToDevice);
-		cudaMemcpy(xj_GPU, xj, sizeof(double)*Nparticles, cudaMemcpyHostToDevice);
-		cudaMemcpy(yj_GPU, yj, sizeof(double)*Nparticles, cudaMemcpyHostToDevice);
-		cudaMemcpy(CDF_GPU, CDF, sizeof(double)*Nparticles, cudaMemcpyHostToDevice);
-		cudaMemcpy(u_GPU, u, sizeof(double)*Nparticles, cudaMemcpyHostToDevice);
-		long long end_copy = get_time();
-		//Set number of threads
-		int num_blocks = ceil((double) Nparticles/(double) threads_per_block);
-		
-		//KERNEL FUNCTION CALL
-		kernel <<< num_blocks, threads_per_block >>> (arrayX_GPU, arrayY_GPU, CDF_GPU, u_GPU, xj_GPU, yj_GPU, Nparticles);
-                cudaDeviceSynchronize();
-                long long start_copy_back = get_time();
-		//CUDA memory copying back from GPU to CPU memory
-		cudaMemcpy(yj, yj_GPU, sizeof(double)*Nparticles, cudaMemcpyDeviceToHost);
-		cudaMemcpy(xj, xj_GPU, sizeof(double)*Nparticles, cudaMemcpyDeviceToHost);
-		long long end_copy_back = get_time();
-		printf("SENDING TO GPU TOOK: %lf\n", elapsed_time(start_copy, end_copy));
-		printf("CUDA EXEC TOOK: %lf\n", elapsed_time(end_copy, start_copy_back));
-		printf("SENDING BACK FROM GPU TOOK: %lf\n", elapsed_time(start_copy_back, end_copy_back));
-		long long xyj_time = get_time();
-		printf("TIME TO CALC NEW ARRAY X AND Y TOOK: %f\n", elapsed_time(u_time, xyj_time));
-		
-		for(x = 0; x < Nparticles; x++){
-			//reassign arrayX and arrayY
-			arrayX[x] = xj[x];
-			arrayY[x] = yj[x];
-			weights[x] = 1/((double)(Nparticles));
-		}
-		long long reset = get_time();
-		printf("TIME TO RESET WEIGHTS TOOK: %f\n", elapsed_time(xyj_time, reset));
-	}
-	
-	//CUDA freeing of memory
-	cudaFree(u_GPU);
-	cudaFree(CDF_GPU);
-	cudaFree(yj_GPU);
-	cudaFree(xj_GPU);
-	cudaFree(arrayY_GPU);
-	cudaFree(arrayX_GPU);
-	
-	//free memory
-	free(disk);
-	free(objxy);
-	free(weights);
-	free(likelihood);
-	free(arrayX);
-	free(arrayY);
-	free(xj);
-	free(yj);
-	free(CDF);
-	free(u);
-	free(ind);
+  int max_size = IszX*IszY*Nfr;
+  long long start = get_time();
+  //original particle centroid
+  double xe = roundDouble(IszY/2.0);
+  double ye = roundDouble(IszX/2.0);
+        
+  //expected object locations, compared to center
+  int radius = 5;
+  int diameter = radius*2 - 1;
+  int * disk = (int *)calloc(diameter*diameter, sizeof(int));
+  strelDisk(disk, radius);
+  int countOnes = 0;
+  int x, y;
+  for(x = 0; x < diameter; x++){
+    for(y = 0; y < diameter; y++){
+      if(disk[x*diameter + y] == 1)
+        countOnes++;
+    }
+  }
+  double * objxy = (double *)calloc(countOnes*2, sizeof(double));
+  getneighbors(disk, countOnes, objxy, radius);
+
+  long long get_neighbors = get_time();
+  printf("TIME TO GET NEIGHBORS TOOK: %f\n", elapsed_time(start, get_neighbors));
+  //initial weights are all equal (1/Nparticles)
+  double * weights = (double *)calloc(Nparticles, sizeof(double));
+  for(x = 0; x < Nparticles; x++){
+    weights[x] = 1/((double)(Nparticles));
+  }
+  long long get_weights = get_time();
+  printf("TIME TO GET WEIGHTSTOOK: %f\n", elapsed_time(get_neighbors, get_weights));
+  //initial likelihood to 0.0
+  double * likelihood = (double *)calloc(Nparticles, sizeof(double));
+  double * arrayX = (double *)calloc(Nparticles, sizeof(double));
+  double * arrayY = (double *)calloc(Nparticles, sizeof(double));
+  double * xj = (double *)calloc(Nparticles, sizeof(double));
+  double * yj = (double *)calloc(Nparticles, sizeof(double));
+  double * CDF = (double *)calloc(Nparticles, sizeof(double));
+
+  //GPU copies of arrays
+  double * arrayX_GPU;
+  double * arrayY_GPU;
+  double * xj_GPU;
+  double * yj_GPU;
+  double * CDF_GPU;
+
+  int * ind = (int *)calloc(countOnes, sizeof(int));
+  double * u = (double *)calloc(Nparticles, sizeof(double));
+  double * u_GPU;
+
+  //CUDA memory allocation
+  check_error(cudaMalloc((void **) &arrayX_GPU, sizeof(double)*Nparticles));
+  check_error(cudaMalloc((void **) &arrayY_GPU, sizeof(double)*Nparticles));
+  check_error(cudaMalloc((void **) &xj_GPU, sizeof(double)*Nparticles));
+  check_error(cudaMalloc((void **) &yj_GPU, sizeof(double)*Nparticles));
+  check_error(cudaMalloc((void **) &CDF_GPU, sizeof(double)*Nparticles));
+  check_error(cudaMalloc((void **) &u_GPU, sizeof(double)*Nparticles));
+
+  for(x = 0; x < Nparticles; x++){
+    arrayX[x] = xe;
+    arrayY[x] = ye;
+  }
+  int k;
+  //double * Ik = (double *)calloc(IszX*IszY, sizeof(double));
+  int indX, indY;
+  for(k = 1; k < Nfr; k++){
+    long long set_arrays = get_time();
+    //printf("TIME TO SET ARRAYS TOOK: %f\n", elapsed_time(get_weights, set_arrays));
+    //apply motion model
+    //draws sample from motion model (random walk). The only prior information
+    //is that the object moves 2x as fast as in the y direction
+
+    for(x = 0; x < Nparticles; x++){
+      arrayX[x] = arrayX[x] + 1.0 + 5.0*randn(seed, x);
+      arrayY[x] = arrayY[x] - 2.0 + 2.0*randn(seed, x);
+    }
+    //particle filter likelihood
+    long long error = get_time();
+    printf("TIME TO SET ERROR TOOK: %f\n", elapsed_time(set_arrays, error));
+    for(x = 0; x < Nparticles; x++){
+
+      //compute the likelihood: remember our assumption is that you know
+      // foreground and the background image intensity distribution.
+      // Notice that we consider here a likelihood ratio, instead of
+      // p(z|x). It is possible in this case. why? a hometask for you.
+      //calc ind
+      for(y = 0; y < countOnes; y++){
+        indX = roundDouble(arrayX[x]) + objxy[y*2 + 1];
+        indY = roundDouble(arrayY[x]) + objxy[y*2];
+        ind[y] = fabs(indX*IszY*Nfr + indY*Nfr + k);
+        if(ind[y] >= max_size)
+          ind[y] = 0;
+      }
+      likelihood[x] = calcLikelihoodSum(I, ind, countOnes);
+      likelihood[x] = likelihood[x]/countOnes;
+    }
+    long long likelihood_time = get_time();
+    printf("TIME TO GET LIKELIHOODS TOOK: %f\n", elapsed_time(error, likelihood_time));
+    // update & normalize weights
+    // using equation (63) of Arulampalam Tutorial
+    for(x = 0; x < Nparticles; x++){
+      weights[x] = weights[x] * exp(likelihood[x]);
+    }
+    long long exponential = get_time();
+    printf("TIME TO GET EXP TOOK: %f\n", elapsed_time(likelihood_time, exponential));
+    double sumWeights = 0;
+    for(x = 0; x < Nparticles; x++){
+      sumWeights += weights[x];
+    }
+    long long sum_time = get_time();
+    printf("TIME TO SUM WEIGHTS TOOK: %f\n", elapsed_time(exponential, sum_time));
+    for(x = 0; x < Nparticles; x++){
+      weights[x] = weights[x]/sumWeights;
+    }
+    long long normalize = get_time();
+    printf("TIME TO NORMALIZE WEIGHTS TOOK: %f\n", elapsed_time(sum_time, normalize));
+    xe = 0;
+    ye = 0;
+    // estimate the object location by expected values
+    for(x = 0; x < Nparticles; x++){
+      xe += arrayX[x] * weights[x];
+      ye += arrayY[x] * weights[x];
+    }
+    long long move_time = get_time();
+    printf("TIME TO MOVE OBJECT TOOK: %f\n", elapsed_time(normalize, move_time));
+    printf("XE: %lf\n", xe);
+    printf("YE: %lf\n", ye);
+    double distance = sqrt( pow((double)(xe-(int)roundDouble(IszY/2.0)),2) + pow((double)(ye-(int)roundDouble(IszX/2.0)),2) );
+    printf("%lf\n", distance);
+    //display(hold off for now)
+
+    //pause(hold off for now)
+
+    //resampling
+
+    CDF[0] = weights[0];
+    for(x = 1; x < Nparticles; x++){
+      CDF[x] = weights[x] + CDF[x-1];
+    }
+    long long cum_sum = get_time();
+    printf("TIME TO CALC CUM SUM TOOK: %f\n", elapsed_time(move_time, cum_sum));
+    double u1 = (1/((double)(Nparticles)))*randu(seed, 0);
+    for(x = 0; x < Nparticles; x++){
+      u[x] = u1 + x/((double)(Nparticles));
+    }
+    long long u_time = get_time();
+    printf("TIME TO CALC U TOOK: %f\n", elapsed_time(cum_sum, u_time));
+    long long start_copy = get_time();
+    //CUDA memory copying from CPU memory to GPU memory
+    cudaMemcpy(arrayX_GPU, arrayX, sizeof(double)*Nparticles, cudaMemcpyHostToDevice);
+    cudaMemcpy(arrayY_GPU, arrayY, sizeof(double)*Nparticles, cudaMemcpyHostToDevice);
+    cudaMemcpy(xj_GPU, xj, sizeof(double)*Nparticles, cudaMemcpyHostToDevice);
+    cudaMemcpy(yj_GPU, yj, sizeof(double)*Nparticles, cudaMemcpyHostToDevice);
+    cudaMemcpy(CDF_GPU, CDF, sizeof(double)*Nparticles, cudaMemcpyHostToDevice);
+    cudaMemcpy(u_GPU, u, sizeof(double)*Nparticles, cudaMemcpyHostToDevice);
+    long long end_copy = get_time();
+    //Set number of threads
+    int num_blocks = ceil((double) Nparticles/(double) threads_per_block);
+
+    //KERNEL FUNCTION CALL
+    kernel <<< num_blocks, threads_per_block >>> (arrayX_GPU, arrayY_GPU, CDF_GPU, u_GPU, xj_GPU, yj_GPU, Nparticles);
+    cudaDeviceSynchronize();
+    long long start_copy_back = get_time();
+    //CUDA memory copying back from GPU to CPU memory
+    cudaMemcpy(yj, yj_GPU, sizeof(double)*Nparticles, cudaMemcpyDeviceToHost);
+    cudaMemcpy(xj, xj_GPU, sizeof(double)*Nparticles, cudaMemcpyDeviceToHost);
+    long long end_copy_back = get_time();
+    printf("SENDING TO GPU TOOK: %lf\n", elapsed_time(start_copy, end_copy));
+    printf("CUDA EXEC TOOK: %lf\n", elapsed_time(end_copy, start_copy_back));
+    printf("SENDING BACK FROM GPU TOOK: %lf\n", elapsed_time(start_copy_back, end_copy_back));
+    long long xyj_time = get_time();
+    printf("TIME TO CALC NEW ARRAY X AND Y TOOK: %f\n", elapsed_time(u_time, xyj_time));
+
+    for(x = 0; x < Nparticles; x++){
+      //reassign arrayX and arrayY
+      arrayX[x] = xj[x];
+      arrayY[x] = yj[x];
+      weights[x] = 1/((double)(Nparticles));
+    }
+    long long reset = get_time();
+    printf("TIME TO RESET WEIGHTS TOOK: %f\n", elapsed_time(xyj_time, reset));
+  }
+
+  //CUDA freeing of memory
+  cudaFree(u_GPU);
+  cudaFree(CDF_GPU);
+  cudaFree(yj_GPU);
+  cudaFree(xj_GPU);
+  cudaFree(arrayY_GPU);
+  cudaFree(arrayX_GPU);
+
+  //free memory
+  free(disk);
+  free(objxy);
+  free(weights);
+  free(likelihood);
+  free(arrayX);
+  free(arrayY);
+  free(xj);
+  free(yj);
+  free(CDF);
+  free(u);
+  free(ind);
 }
 int main(int argc, char * argv[]){
-	
-	char* usage = "naive.out -x <dimX> -y <dimY> -z <Nfr> -np <Nparticles>";
-	//check number of arguments
-	if(argc != 9)
-	{
-		printf("%s\n", usage);
-		return 0;
-	}
-	//check args deliminators
-	if( strcmp( argv[1], "-x" ) ||  strcmp( argv[3], "-y" ) || strcmp( argv[5], "-z" ) || strcmp( argv[7], "-np" ) ) {
-		printf( "%s\n",usage );
-		return 0;
-	}
-	
-	int IszX, IszY, Nfr, Nparticles;
-	
-	//converting a string to a integer
-	if( sscanf( argv[2], "%d", &IszX ) == EOF ) {
-	   printf("ERROR: dimX input is incorrect");
-	   return 0;
-	}
-	
-	if( IszX <= 0 ) {
-		printf("dimX must be > 0\n");
-		return 0;
-	}
-	
-	//converting a string to a integer
-	if( sscanf( argv[4], "%d", &IszY ) == EOF ) {
-	   printf("ERROR: dimY input is incorrect");
-	   return 0;
-	}
-	
-	if( IszY <= 0 ) {
-		printf("dimY must be > 0\n");
-		return 0;
-	}
-	
-	//converting a string to a integer
-	if( sscanf( argv[6], "%d", &Nfr ) == EOF ) {
-	   printf("ERROR: Number of frames input is incorrect");
-	   return 0;
-	}
-	
-	if( Nfr <= 0 ) {
-		printf("number of frames must be > 0\n");
-		return 0;
-	}
-	
-	//converting a string to a integer
-	if( sscanf( argv[8], "%d", &Nparticles ) == EOF ) {
-	   printf("ERROR: Number of particles input is incorrect");
-	   return 0;
-	}
-	
-	if( Nparticles <= 0 ) {
-		printf("Number of particles must be > 0\n");
-		return 0;
-	}
-	//establish seed
-	int * seed = (int *)calloc(Nparticles, sizeof(int));
-	int i;
-	for(i = 0; i < Nparticles; i++)
-		seed[i] = time(0)*i;
-	//malloc matrix
-	int * I = (int *)calloc(IszX*IszY*Nfr, sizeof(int));
-	long long start = get_time();
-	//call video sequence
-	videoSequence(I, IszX, IszY, Nfr, seed);
-	long long endVideoSequence = get_time();
-	printf("VIDEO SEQUENCE TOOK %f\n", elapsed_time(start, endVideoSequence));
-	//call particle filter
-	particleFilter(I, IszX, IszY, Nfr, seed, Nparticles);
-	long long endParticleFilter = get_time();
-	printf("PARTICLE FILTER TOOK %f\n", elapsed_time(endVideoSequence, endParticleFilter));
-	printf("ENTIRE PROGRAM TOOK %f\n", elapsed_time(start, endParticleFilter));
-	
-	free(seed);
-	free(I);
-	return 0;
+  char* usage = "naive.out -x <dimX> -y <dimY> -z <Nfr> -np <Nparticles>";
+  //check number of arguments
+  if(argc != 9)
+  {
+    printf("%s\n", usage);
+    return 0;
+  }
+  //check args deliminators
+  if( strcmp( argv[1], "-x" ) ||  strcmp( argv[3], "-y" ) || strcmp( argv[5], "-z" ) || strcmp( argv[7], "-np" ) ) {
+    printf( "%s\n",usage );
+    return 0;
+  }
+
+  int IszX, IszY, Nfr, Nparticles;
+
+  //converting a string to a integer
+  if( sscanf( argv[2], "%d", &IszX ) == EOF ) {
+    printf("ERROR: dimX input is incorrect");
+    return 0;
+  }
+
+  if( IszX <= 0 ) {
+    printf("dimX must be > 0\n");
+    return 0;
+  }
+
+  //converting a string to a integer
+  if( sscanf( argv[4], "%d", &IszY ) == EOF ) {
+    printf("ERROR: dimY input is incorrect");
+    return 0;
+  }
+
+  if( IszY <= 0 ) {
+    printf("dimY must be > 0\n");
+    return 0;
+  }
+
+  //converting a string to a integer
+  if( sscanf( argv[6], "%d", &Nfr ) == EOF ) {
+    printf("ERROR: Number of frames input is incorrect");
+    return 0;
+  }
+
+  if( Nfr <= 0 ) {
+    printf("number of frames must be > 0\n");
+    return 0;
+  }
+
+  //converting a string to a integer
+  if( sscanf( argv[8], "%d", &Nparticles ) == EOF ) {
+    printf("ERROR: Number of particles input is incorrect");
+    return 0;
+  }
+
+  if( Nparticles <= 0 ) {
+    printf("Number of particles must be > 0\n");
+    return 0;
+  }
+  //establish seed
+  int * seed = (int *)calloc(Nparticles, sizeof(int));
+  int i;
+  for(i = 0; i < Nparticles; i++)
+    seed[i] = time(0)*i;
+  //malloc matrix
+  int * I = (int *)calloc(IszX*IszY*Nfr, sizeof(int));
+  long long start = get_time();
+  //call video sequence
+  videoSequence(I, IszX, IszY, Nfr, seed);
+  long long endVideoSequence = get_time();
+  printf("VIDEO SEQUENCE TOOK %f\n", elapsed_time(start, endVideoSequence));
+  //call particle filter
+  particleFilter(I, IszX, IszY, Nfr, seed, Nparticles);
+  long long endParticleFilter = get_time();
+  printf("PARTICLE FILTER TOOK %f\n", elapsed_time(endVideoSequence, endParticleFilter));
+  printf("ENTIRE PROGRAM TOOK %f\n", elapsed_time(start, endParticleFilter));
+
+  free(seed);
+  free(I);
+  return 0;
 }

--- a/src/cuda/rodinia/3.1/cuda/particlefilter/ex_particle_CUDA_naive_seq.cu
+++ b/src/cuda/rodinia/3.1/cuda/particlefilter/ex_particle_CUDA_naive_seq.cu
@@ -341,7 +341,7 @@ void videoSequence(int * I, int IszX, int IszY, int Nfr, int * seed){
 	}
 	
 	/*dilate matrix*/
-	int * newMatrix = (int *)malloc(sizeof(int)*IszX*IszY*Nfr);
+	int * newMatrix = (int *)calloc(IszX*IszY*Nfr, sizeof(int));
 	imdilate_disk(I, IszX, IszY, Nfr, 5, newMatrix);
 	int x, y;
 	for(x = 0; x < IszX; x++){
@@ -416,7 +416,7 @@ void particleFilter(int * I, int IszX, int IszY, int Nfr, int * seed, int Nparti
 	//expected object locations, compared to center
 	int radius = 5;
 	int diameter = radius*2 - 1;
-	int * disk = (int *)malloc(diameter*diameter*sizeof(int));
+	int * disk = (int *)calloc(diameter*diameter, sizeof(int));
 	strelDisk(disk, radius);
 	int countOnes = 0;
 	int x, y;
@@ -426,25 +426,25 @@ void particleFilter(int * I, int IszX, int IszY, int Nfr, int * seed, int Nparti
 				countOnes++;
 		}
 	}
-	double * objxy = (double *)malloc(countOnes*2*sizeof(double));
+	double * objxy = (double *))calloc(countOnes*2, sizeof(double));
 	getneighbors(disk, countOnes, objxy, radius);
 	
 	long long get_neighbors = get_time();
 	printf("TIME TO GET NEIGHBORS TOOK: %f\n", elapsed_time(start, get_neighbors));
 	//initial weights are all equal (1/Nparticles)
-	double * weights = (double *)malloc(sizeof(double)*Nparticles);
+	double * weights = (double *)calloc(Nparticles, sizeof(double));
 	for(x = 0; x < Nparticles; x++){
 		weights[x] = 1/((double)(Nparticles));
 	}
 	long long get_weights = get_time();
 	printf("TIME TO GET WEIGHTSTOOK: %f\n", elapsed_time(get_neighbors, get_weights));
 	//initial likelihood to 0.0
-	double * likelihood = (double *)malloc(sizeof(double)*Nparticles);
-	double * arrayX = (double *)malloc(sizeof(double)*Nparticles);
-	double * arrayY = (double *)malloc(sizeof(double)*Nparticles);
-	double * xj = (double *)malloc(sizeof(double)*Nparticles);
-	double * yj = (double *)malloc(sizeof(double)*Nparticles);
-	double * CDF = (double *)malloc(sizeof(double)*Nparticles);
+	double * likelihood = (double *)calloc(Nparticles, sizeof(double);
+	double * arrayX = (double *)calloc(Nparticles, sizeof(double);
+	double * arrayY = (double *)calloc(Nparticles, sizeof(double);
+	double * xj = (double *)calloc(Nparticles, sizeof(double);
+	double * yj = (double *)calloc(Nparticles, sizeof(double);
+	double * CDF = (double *)calloc(Nparticles, sizeof(double);
 	
 	//GPU copies of arrays
 	double * arrayX_GPU;
@@ -453,8 +453,8 @@ void particleFilter(int * I, int IszX, int IszY, int Nfr, int * seed, int Nparti
 	double * yj_GPU;
 	double * CDF_GPU;
 	
-	int * ind = (int*)malloc(sizeof(int)*countOnes);
-	double * u = (double *)malloc(sizeof(double)*Nparticles);
+	int * ind = (int *)calloc(countOnes, sizeof(int));
+	double * u = (double *)calloc(Nparticles, sizeof(double);
 	double * u_GPU;
 	
 	//CUDA memory allocation
@@ -470,7 +470,7 @@ void particleFilter(int * I, int IszX, int IszY, int Nfr, int * seed, int Nparti
 		arrayY[x] = ye;
 	}
 	int k;
-	//double * Ik = (double *)malloc(sizeof(double)*IszX*IszY);
+	//double * Ik = (double *)calloc(IszX*IszY, sizeof(double));
 	int indX, indY;
 	for(k = 1; k < Nfr; k++){
 		long long set_arrays = get_time();
@@ -673,12 +673,12 @@ int main(int argc, char * argv[]){
 		return 0;
 	}
 	//establish seed
-	int * seed = (int *)malloc(sizeof(int)*Nparticles);
+	int * seed = (int *)calloc(Nparticles, sizeof(int));
 	int i;
 	for(i = 0; i < Nparticles; i++)
 		seed[i] = time(0)*i;
 	//malloc matrix
-	int * I = (int *)malloc(sizeof(int)*IszX*IszY*Nfr);
+	int * I = (int *)calloc(IszX*IszY*Nfr, sizeof(int));
 	long long start = get_time();
 	//call video sequence
 	videoSequence(I, IszX, IszY, Nfr, seed);


### PR DESCRIPTION
The malloc for the imgsrc filename in dwt2d leaks memory because it
does not allocate space for the trailing \0 to end the string.  This
commit fixes that.