### PR TITLE
fix 4.2 in setup_environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/cuda/rodinia/3.1/cuda/nn/nn
 src/cuda/rodinia/3.1/cuda/particlefilter/particlefilter_float
 src/cuda/rodinia/3.1/cuda/particlefilter/particlefilter_naive
 src/cuda/rodinia/3.1/cuda/pathfinder/pathfinder
+4.2

--- a/src/setup_environment
+++ b/src/setup_environment
@@ -15,7 +15,7 @@ if [ ! -d $GPUAPPS_ROOT/4.2/ ]; then
     make -j -i -C $NVIDIA_COMPUTE_SDK_LOCATION/
 else
     echo "SDK 4.2 detected"
-    export NVIDIA_COMPUTE_SDK_LOCATION=`pwd`/4.2
+    export NVIDIA_COMPUTE_SDK_LOCATION=$GPUAPPS_ROOT/4.2
 fi
 if [ ! -n "$CUDA_INSTALL_PATH" ]; then
     echo "ERROR *** CUDA_INSTALL_PATH not set;"

--- a/src/setup_environment
+++ b/src/setup_environment
@@ -2,7 +2,7 @@
 export GPUAPPS_SETUP_ENVIRONMENT_WAS_RUN=
 export GPUAPPS_ROOT="$( cd "$( dirname "$BASH_SOURCE" )" && pwd )"/../
 export CUDA_PATH=$CUDA_INSTALL_PATH
-if [ ! -d 'pwd'/4.2 ]; then
+if [ ! -d ./4.2/ ]; then
     echo "SDK 4.2 Not detected - installing and building"
     if [ ! -f ./gpucomputingsdk_4.2.9_linux.run ]; then
         wget http://developer.download.nvidia.com/compute/cuda/4_2/rel/sdk/gpucomputingsdk_4.2.9_linux.run
@@ -11,7 +11,10 @@ if [ ! -d 'pwd'/4.2 ]; then
     ./gpucomputingsdk_4.2.9_linux.run -- --prefix=`pwd`/4.2 --cudaprefix=$CUDA_INSTALL_PATH
     export NVIDIA_COMPUTE_SDK_LOCATION=`pwd`/4.2
     rm ./gpucomputingsdk_4.2.9_linux.run
-    # make -j -i -C $NVIDIA_COMPUTE_SDK_LOCATION/
+    make -j -i -C $NVIDIA_COMPUTE_SDK_LOCATION/
+else
+    echo "SDK 4.2 detected"
+    export NVIDIA_COMPUTE_SDK_LOCATION=`pwd`/4.2
 fi
 if [ ! -n "$CUDA_INSTALL_PATH" ]; then
     echo "ERROR *** CUDA_INSTALL_PATH not set;"

--- a/src/setup_environment
+++ b/src/setup_environment
@@ -2,15 +2,16 @@
 export GPUAPPS_SETUP_ENVIRONMENT_WAS_RUN=
 export GPUAPPS_ROOT="$( cd "$( dirname "$BASH_SOURCE" )" && pwd )"/../
 export CUDA_PATH=$CUDA_INSTALL_PATH
-if [ ! -d ./4.2/ ]; then
+if [ ! -d $GPUAPPS_ROOT/4.2/ ]; then
     echo "SDK 4.2 Not detected - installing and building"
-    if [ ! -f ./gpucomputingsdk_4.2.9_linux.run ]; then
-        wget http://developer.download.nvidia.com/compute/cuda/4_2/rel/sdk/gpucomputingsdk_4.2.9_linux.run
+    if [ ! -f $GPUAPPS_ROOT/gpucomputingsdk_4.2.9_linux.run ]; then
+        wget http://developer.download.nvidia.com/compute/cuda/4_2/rel/sdk/gpucomputingsdk_4.2.9_linux.run -O \
+        $GPUAPPS_ROOT/gpucomputingsdk_4.2.9_linux.run
     fi
-    chmod u+x gpucomputingsdk_4.2.9_linux.run
-    ./gpucomputingsdk_4.2.9_linux.run -- --prefix=`pwd`/4.2 --cudaprefix=$CUDA_INSTALL_PATH
-    export NVIDIA_COMPUTE_SDK_LOCATION=`pwd`/4.2
-    rm ./gpucomputingsdk_4.2.9_linux.run
+    chmod u+x $GPUAPPS_ROOT/gpucomputingsdk_4.2.9_linux.run
+    $GPUAPPS_ROOT/gpucomputingsdk_4.2.9_linux.run -- --prefix=$GPUAPPS_ROOT/4.2 --cudaprefix=$CUDA_INSTALL_PATH
+    export NVIDIA_COMPUTE_SDK_LOCATION=$GPUAPPS_ROOT/4.2
+    rm $GPUAPPS_ROOT/gpucomputingsdk_4.2.9_linux.run
     make -j -i -C $NVIDIA_COMPUTE_SDK_LOCATION/
 else
     echo "SDK 4.2 detected"

--- a/src/setup_environment
+++ b/src/setup_environment
@@ -2,7 +2,17 @@
 export GPUAPPS_SETUP_ENVIRONMENT_WAS_RUN=
 export GPUAPPS_ROOT="$( cd "$( dirname "$BASH_SOURCE" )" && pwd )"/../
 export CUDA_PATH=$CUDA_INSTALL_PATH
-
+if [ ! -d 'pwd'/4.2 ]; then
+    echo "SDK 4.2 Not detected - installing and building"
+    if [ ! -f ./gpucomputingsdk_4.2.9_linux.run ]; then
+        wget http://developer.download.nvidia.com/compute/cuda/4_2/rel/sdk/gpucomputingsdk_4.2.9_linux.run
+    fi
+    chmod u+x gpucomputingsdk_4.2.9_linux.run
+    ./gpucomputingsdk_4.2.9_linux.run -- --prefix=`pwd`/4.2 --cudaprefix=$CUDA_INSTALL_PATH
+    export NVIDIA_COMPUTE_SDK_LOCATION=`pwd`/4.2
+    rm ./gpucomputingsdk_4.2.9_linux.run
+    # make -j -i -C $NVIDIA_COMPUTE_SDK_LOCATION/
+fi
 if [ ! -n "$CUDA_INSTALL_PATH" ]; then
     echo "ERROR *** CUDA_INSTALL_PATH not set;"
     return


### PR DESCRIPTION
- just check for the directory. If the folder is not presented, download COMPUTE_SDK 4.2. If found, simply set env variable without re-downloading. 
- Adding the 4.2 folder to `gitignore`