### PR TITLE
Fix missing cutlass_perf_test binary

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -429,6 +429,7 @@ cutlass:
 	cd ../ && git submodule init && git submodule update
 	$(SETENV) mkdir -p cuda/cutlass-bench/build && cd cuda/cutlass-bench/build && cmake .. -DUSE_GPGPUSIM=1 -DCUTLASS_NVCC_ARCHS=70 && make cutlass_perf_test
 	cd cuda/cutlass-bench/build/tools/test/perf && ln -s -f ../../../../binary.sh . && ./binary.sh
+        cp cuda/cutlass-bench/build/tools/test/perf/cutlass_perf_test $(BINDIR)/$(BINSUBDIR)/
 	cp cuda/cutlass-bench/build/tools/test/perf/cutlass_perf_test $(BINDIR)/$(BINSUBDIR)/cutlass_perf_test_k1
 	cp $(BINDIR)/$(BINSUBDIR)/cutlass_perf_test_k1 $(BINDIR)/$(BINSUBDIR)/cutlass_perf_test_k2
 	cp $(BINDIR)/$(BINSUBDIR)/cutlass_perf_test_k1 $(BINDIR)/$(BINSUBDIR)/cutlass_perf_test_k3


### PR DESCRIPTION
Fix missing cutlass_perf_test binary referenced by:

[https://github.com/accel-sim/accel-sim-framework/blob/0c80a1032e6bdcb7eeee7478f252a7fce58546e2/util/job_launching/apps/define-all-apps.yml#L514](https://github.com/accel-sim/accel-sim-framework/blob/0c80a1032e6bdcb7eeee7478f252a7fce58546e2/util/job_launching/apps/define-all-apps.yml#L514)

The accel-watch merge got rid of this binary, we can either recreate the binary, like this PR does, or we can change the define-all-apps to use any of the new binaries.