### PR TITLE
Add pytorch example submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/cuda/cutlass-bench"]
 	path = src/cuda/cutlass-bench
 	url = https://github.com/NVIDIA/cutlass.git
+[submodule "src/cuda/pytorch_examples"]
+	path = src/cuda/pytorch_examples
+	url = https://github.com/pytorch/examples.git


### PR DESCRIPTION
Simple PR to include the Pytorch Examples (https://github.com/pytorch/examples) repo, mainly replacing the outdated cuDNN MNIST samples. 