### PR TITLE
Pytorch examples integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,7 @@
 [submodule "src/cuda/cuda-samples"]
 	path = src/cuda/cuda-samples
 	url = https://github.com/NVIDIA/cuda-samples.git
+[submodule "src/cuda/pytorch_examples"]
+	path = src/cuda/pytorch_examples
+	url = https://github.com/accel-sim/pytorch_examples.git
+	branch = inference_accelsim_v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "src/cuda/cutlass-bench"]
 	path = src/cuda/cutlass-bench
 	url = https://github.com/NVIDIA/cutlass.git
-[submodule "src/cuda/pytorch_examples"]
-	path = src/cuda/pytorch_examples
-	url = https://github.com/pytorch/examples.git
 [submodule "src/cuda/cuda-samples"]
 	path = src/cuda/cuda-samples
 	url = https://github.com/NVIDIA/cuda-samples.git

--- a/src/Makefile
+++ b/src/Makefile
@@ -500,9 +500,9 @@ cuda_samples:
 pytorch_examples:
 	mkdir -p $(BINDIR)/$(BINSUBDIR)/
 	cp -r cuda/pytorch_examples $(BINDIR)/$(BINSUBDIR)
-	echo "#!/bin/bash\npython pytorch_examples/mnist/main.py --dry-run --epochs=1 --test-batch-size=64" > $(BINDIR)/$(BINSUBDIR)/inference_mnist
+	echo "#!/bin/bash\npython $(BINDIR)/$(BINSUBDIR)/pytorch_examples/mnist/main.py --dry-run --epochs=1 --test-batch-size=64" > $(BINDIR)/$(BINSUBDIR)/inference_mnist
 	chmod u+x $(BINDIR)/$(BINSUBDIR)/inference_mnist
-	echo "#!/bin/bash\npython pytorch_examples/vae/main.py --epochs=1" > $(BINDIR)/$(BINSUBDIR)/inference_vae
+	echo "#!/bin/bash\npython $(BINDIR)/$(BINSUBDIR)/pytorch_examples/vae/main.py --epochs=1" > $(BINDIR)/$(BINSUBDIR)/inference_vae
 	chmod u+x $(BINDIR)/$(BINSUBDIR)/inference_vae
 
 clean_heterosync:
@@ -671,5 +671,10 @@ clean_mlperf_inference:
 clean_mlperf_training:
 	rm -rf $(BINDIR)/$(BINSUBDIR)/mlperf_training
 	
+clean_pytorch_examples:
+	rm -rf $(BINDIR)/$(BINSUBDIR)/pytorch_examples
+	rm -f $(BINDIR)/$(BINSUBDIR)/inference_mnist
+	rm -f $(BINDIR)/$(BINSUBDIR)/inference_vae
+
 clean_cuda_samples:
 	make clean -C ./cuda/cuda-samples

--- a/src/Makefile
+++ b/src/Makefile
@@ -497,6 +497,14 @@ cuda_samples:
 	make -C ./cuda/cuda-samples/
 	find $(GPUAPPS_ROOT)/src/cuda/cuda-samples/bin/x86_64/linux/release -maxdepth 1 -type f -executable -exec mv {} "$(BINDIR)/$(BINSUBDIR)/" \; ;
 
+pytorch_examples:
+	mkdir -p $(BINDIR)/$(BINSUBDIR)/
+	cp -r cuda/pytorch_examples $(BINDIR)/$(BINSUBDIR)
+	echo "#!/bin/bash\npython pytorch_examples/mnist/main.py --dry-run --epochs=1 --test-batch-size=64" > $(BINDIR)/$(BINSUBDIR)/inference_mnist
+	chmod u+x $(BINDIR)/$(BINSUBDIR)/inference_mnist
+	echo "#!/bin/bash\npython pytorch_examples/vae/main.py --epochs=1" > $(BINDIR)/$(BINSUBDIR)/inference_vae
+	chmod u+x $(BINDIR)/$(BINSUBDIR)/inference_vae
+
 clean_heterosync:
 	rm -rf cuda/heterosync
 


### PR DESCRIPTION
Moved to our accel-sim inference-only version of the pytorch examples. Implements MNIST, VAE, (GAT is taking a bit too long to trace, so I'm not entirely happy about it yet).