### PR TITLE
Syntax error encountered when running tracing script (run.sh)

### DIFF
--- a/src/cuda/mlperf_inference/inference_mlperf_bert.sh
+++ b/src/cuda/mlperf_inference/inference_mlperf_bert.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 ORIGINAL_FOLDER=$PWD
-CUDA_VERSION=`nvcc --version | grep release | sed -re 's/.*release ([0-9]+\.[0-9]+).*/\1/'`;
 BASE_MLPERF_DIR=$GPUAPPS_ROOT/bin/$CUDA_VERSION/release/mlperf_inference/
 cd $BASE_MLPERF_DIR
 . ./mlc/bin/activate

--- a/src/cuda/mlperf_inference/inference_mlperf_bert_test.sh
+++ b/src/cuda/mlperf_inference/inference_mlperf_bert_test.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 ORIGINAL_FOLDER=$PWD
-CUDA_VERSION=`nvcc --version | grep release | sed -re 's/.*release ([0-9]+\.[0-9]+).*/\1/'`;
+# CUDA_VERSION=`nvcc --version | grep release | sed -re 's/.*release ([0-9]+\.[0-9]+).*/\1/'`;
+# CUDA_VERSION="12.8"
 BASE_MLPERF_DIR=$GPUAPPS_ROOT/bin/$CUDA_VERSION/release/mlperf_inference/
 cd $BASE_MLPERF_DIR
 . ./mlc/bin/activate

--- a/src/cuda/mlperf_inference/inference_mlperf_bert_test.sh
+++ b/src/cuda/mlperf_inference/inference_mlperf_bert_test.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 
 ORIGINAL_FOLDER=$PWD
-# CUDA_VERSION=`nvcc --version | grep release | sed -re 's/.*release ([0-9]+\.[0-9]+).*/\1/'`;
-# CUDA_VERSION="12.8"
 BASE_MLPERF_DIR=$GPUAPPS_ROOT/bin/$CUDA_VERSION/release/mlperf_inference/
 cd $BASE_MLPERF_DIR
 . ./mlc/bin/activate


### PR DESCRIPTION
This fix addresses the "cd: too many arguments" syntax error encountered due to the incorrect CUDA_VERSION definition in the Bert inference test script. 