### PR TITLE
Add GPGPU-Sim support and migrate parboil driver to Python 3

### DIFF
--- a/src/cuda/GPU_Microbenchmark/hw_def/common/gpuConfig.h
+++ b/src/cuda/GPU_Microbenchmark/hw_def/common/gpuConfig.h
@@ -5,6 +5,8 @@
 #include <cstdlib>
 #include <cstdint>
 #include <iostream>
+#include <fstream>
+#include <sstream>
 #include <cuda_runtime.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -237,46 +239,85 @@ inline unsigned queryGrInfo(uint32_t info_index)
 
 unsigned intilizeDeviceProp(unsigned deviceID, int argc, char *argv[])
 {
-    cudaSetDevice(deviceID);
-    cudaGetDeviceProperties(&deviceProp, deviceID);
+    // Check if running in GPGPU-Sim by looking for gpgpusim.config
+    std::ifstream configFile("gpgpusim.config");
+    bool isGpgpuSim = configFile.is_open();
 
-    int clockRateKHz;
-    cudaDeviceGetAttribute(&clockRateKHz, cudaDevAttrClockRate, deviceID);
+    if (isGpgpuSim) {
+        // Parse gpgpusim.config for available parameters
+        unsigned n_mem = 32, n_sub_partition = 2;  // defaults
+        unsigned l2_nsets = 32, l2_linesize = 128, l2_assoc = 24;  // defaults for L2 per bank
+        std::string line;
+        while (std::getline(configFile, line)) {
+            std::istringstream iss(line);
+            std::string key;
+            if (iss >> key) {
+                if (key == "-gpgpu_n_mem") {
+                    iss >> n_mem;   // number of memory controllers
+                } else if (key == "-gpgpu_n_sub_partition_per_mchannel") {
+                    iss >> n_sub_partition; // number of L2 banks per memory controller
+                } else if (key == "-gpgpu_cache:dl2") {
+                    // Format: X:nsets:linesize:assoc,... where X is any letter
+                    std::string cacheConfig;
+                    iss >> cacheConfig;
+                    // Parse X:nsets:linesize:assoc using sscanf, skip first char
+                    char dummy;
+                    sscanf(cacheConfig.c_str(), "%c:%u:%u:%u", &dummy, &l2_nsets, &l2_linesize, &l2_assoc);
+                }
+            }
+        }
+        configFile.close();
 
-    // core stats
+        // Use struct default values (already initialized in GpuConfig)
+        // Override FBP_COUNT and L2_BANKS from gpgpusim.config
+        config.FBP_COUNT = n_mem;
+        config.L2_BANKS = n_mem * n_sub_partition;
+        // L2_SIZE = (nsets * linesize * assoc) per bank * banks_per_controller * num_controllers
+        size_t l2_size_per_bank = (size_t)l2_nsets * l2_linesize * l2_assoc;
+        config.L2_SIZE = l2_size_per_bank * n_sub_partition * n_mem;
+    } else {
+        // Running on real hardware - query device properties
+        cudaSetDevice(deviceID);
+        cudaGetDeviceProperties(&deviceProp, deviceID);
 
-    config.SM_NUMBER = deviceProp.multiProcessorCount;
-    config.MAX_THREADS_PER_SM = deviceProp.maxThreadsPerMultiProcessor;
-    config.MAX_SHARED_MEM_SIZE = deviceProp.sharedMemPerMultiprocessor;
-    config.WARP_SIZE = deviceProp.warpSize;
-    config.MAX_WARPS_PER_SM =
-        deviceProp.maxThreadsPerMultiProcessor / deviceProp.warpSize;
-    config.MAX_REG_PER_SM = deviceProp.regsPerMultiprocessor;
+        int clockRateKHz;
+        cudaDeviceGetAttribute(&clockRateKHz, cudaDevAttrClockRate, deviceID);
 
-    // threadblock stats
-    config.MAX_THREAD_BLOCK_SIZE = deviceProp.maxThreadsPerBlock;
-    config.MAX_SHARED_MEM_SIZE_PER_BLOCK = deviceProp.sharedMemPerBlock;
-    config.MAX_REG_PER_BLOCK = deviceProp.regsPerBlock;
+        // core stats
+        config.SM_NUMBER = deviceProp.multiProcessorCount;
+        config.MAX_THREADS_PER_SM = deviceProp.maxThreadsPerMultiProcessor;
+        config.MAX_SHARED_MEM_SIZE = deviceProp.sharedMemPerMultiprocessor;
+        config.WARP_SIZE = deviceProp.warpSize;
+        config.MAX_WARPS_PER_SM =
+            deviceProp.maxThreadsPerMultiProcessor / deviceProp.warpSize;
+        config.MAX_REG_PER_SM = deviceProp.regsPerMultiprocessor;
 
-    // launched thread blocks to ensure GPU is fully occupied as much as possible
-    config.THREADS_PER_BLOCK = deviceProp.maxThreadsPerBlock;
-    config.BLOCKS_PER_SM =
-        deviceProp.maxThreadsPerMultiProcessor / deviceProp.maxThreadsPerBlock;
-    config.THREADS_PER_SM = config.BLOCKS_PER_SM * config.THREADS_PER_BLOCK;
-    config.BLOCKS_NUM = config.BLOCKS_PER_SM * config.SM_NUMBER;
-    config.TOTAL_THREADS = config.THREADS_PER_BLOCK * config.BLOCKS_NUM;
+        // threadblock stats
+        config.MAX_THREAD_BLOCK_SIZE = deviceProp.maxThreadsPerBlock;
+        config.MAX_SHARED_MEM_SIZE_PER_BLOCK = deviceProp.sharedMemPerBlock;
+        config.MAX_REG_PER_BLOCK = deviceProp.regsPerBlock;
 
-    // L2 cache
-    config.L2_SIZE = deviceProp.l2CacheSize;
+        // launched thread blocks to ensure GPU is fully occupied as much as possible
+        config.THREADS_PER_BLOCK = deviceProp.maxThreadsPerBlock;
+        config.BLOCKS_PER_SM =
+            deviceProp.maxThreadsPerMultiProcessor / deviceProp.maxThreadsPerBlock;
+        config.THREADS_PER_SM = config.BLOCKS_PER_SM * config.THREADS_PER_BLOCK;
+        config.BLOCKS_NUM = config.BLOCKS_PER_SM * config.SM_NUMBER;
+        config.TOTAL_THREADS = config.THREADS_PER_BLOCK * config.BLOCKS_NUM;
 
-    // memory
-    config.MEM_SIZE = deviceProp.totalGlobalMem;
-    config.MEM_CLK_FREQUENCY = deviceProp.memoryClockRate * 1e-3f;
-    config.MEM_BITWIDTH = deviceProp.memoryBusWidth;
-    config.CLK_FREQUENCY = clockRateKHz * 1e-3f;
+        // L2 cache
+        config.L2_SIZE = deviceProp.l2CacheSize;
 
-    config.FBP_COUNT = queryGrInfo(NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_FBPS);
-    config.L2_BANKS = queryGrInfo(NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_LTCS);
+        // memory
+        config.MEM_SIZE = deviceProp.totalGlobalMem;
+        config.MEM_CLK_FREQUENCY = deviceProp.memoryClockRate * 1e-3f;
+        config.MEM_BITWIDTH = deviceProp.memoryBusWidth;
+        config.CLK_FREQUENCY = clockRateKHz * 1e-3f;
+
+        // Get FBP_COUNT and L2_BANKS from NVIDIA RM API
+        config.FBP_COUNT = queryGrInfo(NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_FBPS);
+        config.L2_BANKS = queryGrInfo(NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_LTCS);
+    }
 
     parseGpuConfigArgs(argc, argv);
     printGpuConfig();

--- a/src/cuda/parboil/driver/__init__.py
+++ b/src/cuda/parboil/driver/__init__.py
@@ -2,14 +2,13 @@
 
 import sys
 import os
-from itertools import imap
 
-import globals
-import actions
-import options
-import parboilfile
-import process
-import benchmark
+from . import globals
+from . import actions
+from . import options
+from . import parboilfile
+from . import process
+from . import benchmark
 
 def run():
     # Print a banner message

--- a/src/cuda/parboil/driver/actions.py
+++ b/src/cuda/parboil/driver/actions.py
@@ -4,24 +4,23 @@
 # call lower-level routines from the process or benchmark modules.
 
 import os
-from itertools import imap
 
-import process
-import benchmark
-import globals
-from text import format_columns
+from . import process
+from . import benchmark
+from . import globals
+from .text import format_columns
 
-from error import ErrorType
+from .error import ErrorType
 
 def benchmark_iter():
     """Iterate over the benchmarks in 'bmks'."""
     # bmks is a dictionary from str to Future(Benchmark)
-    return imap(lambda x: x.get(), globals.benchmarks.itervalues())
+    return map(lambda x: x.get(), globals.benchmarks.values())
 
 def list_benchmarks():
     """List all benchmarks on standard output."""
-    print "Benchmarks:"
-    for bmk in benchmark_iter(): print "  " + bmk.name
+    print("Benchmarks:")
+    for bmk in benchmark_iter(): print("  " + bmk.name)
         
 def describe_benchmarks():
     """Print descriptions of all benchmarks to standard output."""
@@ -30,8 +29,8 @@ def describe_benchmarks():
 def describe_benchmark(bmk):
     """Print a description of one benchmark to standard output."""
 
-    print "  " + bmk.name
-    print format_columns(bmk.describe(), 4)
+    print("  " + bmk.name)
+    print(format_columns(bmk.describe(), 4))
 
 def lookup_benchmark(name):
     """Find a benchmark, given its name.  Returns None if no benchmark
@@ -43,11 +42,11 @@ def lookup_benchmark(name):
         if bmk.invalid is None:
             return bmk
         else:
-            print "Error in benchmark:"
-            print str(bmk.invalid)
+            print("Error in benchmark:")
+            print(str(bmk.invalid))
             return None
     else:
-        print "Cannot find benchmark"
+        print("Cannot find benchmark")
         return None
 
 def with_benchmark_named(name, action):
@@ -62,9 +61,9 @@ def compile_benchmark(bmk, version_name, platform=None):
     """Compile the benchmark 'bmk'."""
     try: impl = bmk.impls[version_name]
     except KeyError:
-        print "Cannot find benchmark version"
+        print("Cannot find benchmark version")
         return
-    
+
     return impl.build(bmk, platform)
 
 def clean_benchmark(bmk, version_name=None, platform=None):
@@ -74,32 +73,32 @@ def clean_benchmark(bmk, version_name=None, platform=None):
     if version_name:
         try: impl = bmk.impls[version_name]
         except KeyError:
-            print "Cannot find benchmark version"
+            print("Cannot find benchmark version")
             return
 
         impl.clean(bmk, platform)
     else:
         # Clean all versions
-        for impl in bmk.impls.itervalues():
+        for impl in bmk.impls.values():
             impl.clean(bmk, platform)
 
 def run_benchmark(bmk, version_name, input_name, check=True, extra_opts=[], platform=None):
     """Run the benchmark 'bmk'."""
     try: impl = bmk.impls[version_name]
     except KeyError:
-        print "Cannot find benchmark version"
+        print("Cannot find benchmark version")
         return ErrorType.CannotFindVersion
-    
+
     try: data = bmk.datas[input_name]
     except KeyError:
-        print "Cannot find data set"
+        print("Cannot find data set")
         return ErrorType.CannotFindDataSet
 
     # Run the benchmark
     ret = impl.run(bmk, data, check, extra_opts=extra_opts, platform=platform)
 
     if ret is not ErrorType.Success:
-        print "Run failed!"
+        print("Run failed!")
         return ret
 
     # Verify the output
@@ -107,10 +106,10 @@ def run_benchmark(bmk, version_name, input_name, check=True, extra_opts=[], plat
         success = impl.check(bmk, data)
 
         if not success:
-            print "Output checking tool detected a mismatch"
+            print("Output checking tool detected a mismatch")
             return ErrorType.OutputMismatch
     else:
-        print "Output was not checked for correctness"
+        print("Output was not checked for correctness")
 
     return ErrorType.Success
 
@@ -118,12 +117,12 @@ def debug_benchmark(bmk, version_name, input_name, check=True, extra_opts=[], pl
     """Debug the benchmark."""
     try: impl = bmk.impls[version_name]
     except KeyError:
-        print "Cannot find benchmark version"
+        print("Cannot find benchmark version")
         return ErrorType.CannotFindVersion
-    
+
     try: data = bmk.datas[input_name]
     except KeyError:
-        print "Cannot find data set"
+        print("Cannot find data set")
         return ErrorType.CannotFindDataSet
 
     # Run the benchmark

--- a/src/cuda/parboil/driver/benchmark.py
+++ b/src/cuda/parboil/driver/benchmark.py
@@ -4,14 +4,15 @@ import sys
 import os
 from os import path
 import re
-from itertools import imap, repeat, chain
+from itertools import repeat, chain
+from functools import reduce
 
-import globals
-import process
-import parboilfile as pbf
-from futures import Future
+from . import globals
+from . import process
+from . import parboilfile as pbf
+from .futures import Future
 
-from error import ErrorType
+from .error import ErrorType
 
 class Benchmark(object):
     """A benchmark.
@@ -36,8 +37,8 @@ class Benchmark(object):
 
         if invalid is None:
             self.path = path
-            self.impls = dict(imap(lambda i: (i.name, i), impls))
-            self.datas = dict(imap(lambda i: (i.name, i), datasets))
+            self.impls = dict(map(lambda i: (i.name, i), impls))
+            self.datas = dict(map(lambda i: (i.name, i), datasets))
             self.descr = description
 
     def createFromName(name):
@@ -77,14 +78,14 @@ class Benchmark(object):
         else:
             header = self.descr
 
-        impls = " ".join([impl.name for impl in self.impls.itervalues()])
-        datas = " ".join([data.name for data in self.datas.itervalues()])
+        impls = " ".join([impl.name for impl in self.impls.values()])
+        datas = " ".join([data.name for data in self.datas.values()])
 
         return header + "\nVersions: " + impls + "\nData sets: " + datas
 
     def instance_check(x):
         if not isinstance(x, Benchmark):
-            raise TypeError, "argument must be an instance of Benchmark"
+            raise TypeError("argument must be an instance of Benchmark")
 
     instance_check = staticmethod(instance_check)
 
@@ -93,7 +94,7 @@ class BenchImpl(object):
 
     def __init__(self, dir, description=None):
         if not isinstance(dir, pbf.Directory):
-            raise TypeEror, "dir must be a directory"
+            raise TypeError("dir must be a directory")
 
         self.name = dir.getName() 
         self.dir = dir
@@ -267,7 +268,7 @@ class BenchDataset(object):
     def __init__(self, dir, in_files=[], out_files=[], parameters=[],
                  description=None):
         if not isinstance(dir, pbf.Directory):
-            raise TypeError, "dir must be a pbf.Directory"
+            raise TypeError("dir must be a pbf.Directory")
 
         self.name = dir.getName()
         self.dir = dir
@@ -290,7 +291,7 @@ class BenchDataset(object):
             # This function is called to see if the input file set
             # guessed by scanning the input directory can be used
             if invalid_default_input_files:
-                raise ValueError, "Cannot infer command line when there are multiple input files in a data set\n(Fix by adding an input DESCRIPTION file)"
+                raise ValueError("Cannot infer command line when there are multiple input files in a data set\n(Fix by adding an input DESCRIPTION file)")
                 
         if input_dir.exists():
             input_descr = process.read_description_file(input_dir)
@@ -323,7 +324,7 @@ class BenchDataset(object):
         output_descr = process.read_description_file(output_dir)
         output_files = output_dir.scanAndReturnNames()
         if len(output_files) > 1:
-            raise ValueError, "Multiple output files not supported"
+            raise ValueError("Multiple output files not supported")
 
         # Concatenate input and output descriptions
         if input_descr and output_descr:
@@ -388,7 +389,7 @@ class BenchDataset(object):
         # desired
         if do_output and self.outFiles:
             if len(self.outFiles) != 1:
-                raise ValueError, "only one output file is supported"
+                raise ValueError("only one output file is supported")
 
             out_file = self.getTemporaryOutputFile(benchmark)
             args.append("-o")
@@ -450,7 +451,7 @@ def find_benchmarks():
     containing the benchmarks."""
 
     if not globals.root:
-        raise ValueError, "root directory has not been set"
+        raise ValueError("root directory has not been set")
 
     # Scan all benchmarks in the 'benchmarks' directory and
     # lazily create benchmark objects.
@@ -462,7 +463,7 @@ def find_benchmarks():
         for bmkdir in globals.benchdir.getScannedChildren():
             bmk = Future(lambda bmkdir=bmkdir: Benchmark.createFromName(bmkdir.getName()))
             db[bmkdir.getName()] = bmk
-    except OSError, e:
+    except OSError as e:
         sys.stdout.write("Benchmark directory not found!\n\n")
         return {}
 

--- a/src/cuda/parboil/driver/options.py
+++ b/src/cuda/parboil/driver/options.py
@@ -9,12 +9,12 @@
 from sys import stdout
 from optparse import OptionParser
 
-import actions
-import globals
+from . import actions
+from . import globals
 
 def invalid_option_message(progname, cmd, args):
-    print "Unrecognized command '" + cmd + "'"
-    print "'" + progname + " help' for options"
+    print("Unrecognized command '" + cmd + "'")
+    print("'" + progname + " help' for options")
 
 # Parsers for each mode.  These take the command line as parameters
 # and return an OptionGetter.
@@ -38,20 +38,20 @@ def help_options(progname, cmd, args):
         if args:
             try: helpcmd = parse_mode_options[args[0]]
             except KeyError:
-                print "No help available for unrecognized command '" + args[0] + "'"
+                print("No help available for unrecognized command '" + args[0] + "'")
                 return None
 
             helpcmd(progname, cmd, args).help()
         else:
-            print "Commands: "
-            print "  help      Display this help message"
-            print "  list      List benchmarks"
-            print "  describe  Show details on a benchmark"
-            print "  clean     Clean up generated files in a benchmark"
-            print "  compile   Compile a benchmark"
-            print "  run       Run a benchmark"
-            print ""
-            print "To get help on a command: " + progname + " help COMMAND"
+            print("Commands: ")
+            print("  help      Display this help message")
+            print("  list      List benchmarks")
+            print("  describe  Show details on a benchmark")
+            print("  clean     Clean up generated files in a benchmark")
+            print("  compile   Compile a benchmark")
+            print("  run       Run a benchmark")
+            print("")
+            print("To get help on a command: " + progname + " help COMMAND")
 
         return None
 
@@ -63,7 +63,7 @@ def list_options(progname, cmd, args):
 
     def run():
         if args:
-            print "Unexpected parameter or option after 'list'"
+            print("Unexpected parameter or option after 'list'")
             return None
         else:
             return actions.list_benchmarks
@@ -77,7 +77,7 @@ def describe_options(progname, cmd, args):
     def run():
         (opts, pos) = parser.parse_args(args)
         if len(pos) > 1:
-            print "Too many parameters after 'describe'"
+            print("Too many parameters after 'describe'")
             return None
         elif len(pos) == 0:
             return actions.describe_benchmarks
@@ -100,7 +100,7 @@ def clean_options(progname, cmd, args):
         globals.verbose = opts.verbose
 
         if len(pos) == 0:
-            print "Expecting two or three parameters after 'clean'"
+            print("Expecting two or three parameters after 'clean'")
             return None
         elif len(pos) == 1:
             bmkname = pos[0]
@@ -115,7 +115,7 @@ def clean_options(progname, cmd, args):
             platform = pos[2]
             return lambda: actions.with_benchmark_named(bmkname, lambda b: actions.clean_benchmark(b, ver, platform))
         else:
-            print "Too many parameters after 'clean'"
+            print("Too many parameters after 'clean'")
             return None
 
     return OptionGetter(parser.print_help, run)
@@ -132,7 +132,7 @@ def compile_options(progname, cmd, args):
         globals.verbose = opts.verbose
 
         if not len(pos) in [2, 3]:
-            print "Expecting two or three parameters after 'compile'"
+            print("Expecting two or three parameters after 'compile'")
             return None
         else:
             bmkname = pos[0]
@@ -159,7 +159,7 @@ def run_options(progname, cmd, args):
         (opts, pos) = parser.parse_args(args)
         globals.verbose = opts.verbose
         if not len(pos) in [3, 4]:
-            print "Expecting three or four parameters after 'run'"
+            print("Expecting three or four parameters after 'run'")
             return None
         else:
             bmkname = pos[0]
@@ -189,7 +189,7 @@ def debug_options(progname, cmd, args):
         (opts, pos) = parser.parse_args(args)
         globals.verbose = opts.verbose
         if not len(pos) in [3, 4]:
-            print "Expecting three or four parameters after 'run'"
+            print("Expecting three or four parameters after 'run'")
             return None
         else:
             bmkname = pos[0]

--- a/src/cuda/parboil/driver/parboilfile.py
+++ b/src/cuda/parboil/driver/parboilfile.py
@@ -42,42 +42,42 @@ class FileBase(object):
         is not required to exist, then it is valid.  If the file exists,
         then ths function returns the same results as exists().  This function
         should not raise an exception."""
-        raise NotImplementedError, "'FileBase' is an abstract base class"
+        raise NotImplementedError("'FileBase' is an abstract base class")
 
     def exists(self):
         """f.exists() -> bool
 
         Test whether this file exists and is a valid file.  This function
         should not raise an exception."""
-        raise NotImplementedError, "'FileBase' is an abstract base class"
+        raise NotImplementedError("'FileBase' is an abstract base class")
 
     def isDir(self):
         """f.isDir() -> bool
 
         Test whether this FileBase object represents a directory.  This
         function should not access the file system."""
-        raise NotImplementedError, "'FileBase' is an abstract base class"
+        raise NotImplementedError("'FileBase' is an abstract base class")
 
     def isFile(self):
         """f.isFile() -> bool
 
         Test whether this FileBase object represents an ordinary file.  This
         function should not access the file system."""
-        raise NotImplementedError, "'FileBase' is an abstract base class"
+        raise NotImplementedError("'FileBase' is an abstract base class")
 
     def getPath(self):
         """f.getPath() -> string
 
         Get the path to this file.  This function should not access the
         file system."""
-        raise NotImplementedError, "'FileBase' is an abstract base class"
+        raise NotImplementedError("'FileBase' is an abstract base class")
 
     def getName(self):
         """f.getName() -> string
 
-        Get the name of this file.  This function should not access the 
+        Get the name of this file.  This function should not access the
         file system."""
-        raise NotImplementedError, "'FileBase' is an abstract base class"
+        raise NotImplementedError("'FileBase' is an abstract base class")
 
 class File(FileBase):
     """A description of a file."""
@@ -92,21 +92,21 @@ class File(FileBase):
         self._name = path.split(fpath)[1]
 
     def exists(self):
-    	try: return path.isfile(self.getPath())
-    	except OSError: return False # handles file-not-found case
+        try: return path.isfile(self.getPath())
+        except OSError: return False # handles file-not-found case
 
     def valid(self):
-    	if self._must_exist:
-    	    return self.exists()
-    	else:
-    	    return True
+        if self._must_exist:
+            return self.exists()
+        else:
+            return True
 
     def isDir(self): return False
 
     def isFile(self): return True
 
     def getPath(self):
-    	return self._path
+        return self._path
 
     def getName(self):
         return self._name
@@ -115,8 +115,8 @@ class File(FileBase):
         """f.open(mode, buffering) -> file object
 
         Open the file."""
-        if buffering is None: return file(self.getPath(), mode)
-        else: return file(self.getPath(), mode, buffering)
+        if buffering is None: return open(self.getPath(), mode)
+        else: return open(self.getPath(), mode, buffering=buffering)
 
 class Directory(FileBase):
     """A description of a directory."""
@@ -134,7 +134,7 @@ class Directory(FileBase):
         for f in contents_list:
             assert isinstance(f, FileBase)
         if scan_func and not must_exist:
-            raise ValueError, "Invalid combination of arguments: scan_func is provided but must_exist is False"
+            raise ValueError("Invalid combination of arguments: scan_func is provided but must_exist is False")
 
         self._realContents = None
         self._interesting = scan_func
@@ -144,20 +144,20 @@ class Directory(FileBase):
         self._name = path.split(dpath)[1]
 
     def exists(self):
-    	try: return path.isdir(self.getPath())
-    	except OSError: return False # handles file-not-found case
+        try: return path.isdir(self.getPath())
+        except OSError: return False # handles file-not-found case
 
     def valid(self):
 
-    	if self._mustExist and not self.exists():
-    	    return False
-    	
-    	if self.exists():
-    	    for file in self._contentsList:
-    	        if not file.valid(): return False
-    	    if self._realContents is not None:
-    	        for file in self._realContents:
-    	            if not file.valid(): return False
+        if self._mustExist and not self.exists():
+            return False
+
+        if self.exists():
+            for file in self._contentsList:
+                if not file.valid(): return False
+            if self._realContents is not None:
+                for file in self._realContents:
+                    if not file.valid(): return False
 
         #Children are valid, and either exists or doesn't have to
         return True
@@ -167,7 +167,7 @@ class Directory(FileBase):
     def isFile(self): return False
 
     def getPath(self):
-    	return self._path
+        return self._path
 
     def getName(self):
         return self._name
@@ -178,21 +178,21 @@ class Directory(FileBase):
         if self._realContents is not None: return
         
         # Scan the directory and assign self._realContents
-        if not self.exists(): 
-            raise OSError, "Directory '" + self._name + "' does not exist."
-        
+        if not self.exists():
+            raise OSError("Directory '" + self._name + "' does not exist.")
+
         all_contents = os.listdir(self.getPath())
 
-	def has_file_of_name(name):
-	    for x in self._contentsList:
-	        if x.getName() == name:
-	            return True
-	    return False
+        def has_file_of_name(name):
+            for x in self._contentsList:
+                if x.getName() == name:
+                    return True
+            return False
 
-        new_contents = filter(lambda x: not has_file_of_name(x), all_contents)
+        new_contents = list(filter(lambda x: not has_file_of_name(x), all_contents))
 
-        self._realContents = filter(lambda x: x is not None, 
-        	[self._interesting(path.join(self.getPath(), x)) for x in new_contents])
+        self._realContents = list(filter(lambda x: x is not None,
+            [self._interesting(path.join(self.getPath(), x)) for x in new_contents]))
 
     def touch(self):
         """d.touch() -- create this directory if it doesn't exist.
@@ -206,7 +206,7 @@ class Directory(FileBase):
             if path.isdir(dirpath):
                 return
             elif path.exists(dirpath):
-                raise OSError, "Path exists but is not a directory"
+                raise OSError("Path exists but is not a directory")
             else:
                 (head, tail) = path.split(dirpath)
                 if head: touch_dir(head)
@@ -233,7 +233,7 @@ class Directory(FileBase):
         or is ignored by this directory."""
         (basepathname, filename) = path.split(pathname)
         if basepathname != self.getPath():
-            raise ValueError, "Path is not a child of this directory"
+            raise ValueError("Path is not a child of this directory")
         return self.getChildByName(filename)
 
     def getChildren(self):
@@ -266,7 +266,7 @@ class Directory(FileBase):
         Adds parameter to its expected children list.  Returns None.  
         Parameter must be a FileBase obejct."""
         if not isinstance(newchild, FileBase):
-            raise TypeError, "parameter must be a FileBase object"
+            raise TypeError("parameter must be a FileBase object")
 
         self._contentsList.append(newchild)
 

--- a/src/cuda/parboil/driver/process.py
+++ b/src/cuda/parboil/driver/process.py
@@ -5,10 +5,10 @@
 import os
 import os.path as path
 import stat
-import parboilfile as pbf
-from itertools import imap, ifilter, chain
+from . import parboilfile as pbf
+from itertools import chain
 
-import globals
+from . import globals
 
 #def scan_for_benchmarks():
 #    """Returns a file scanner for the benchmarks directory repository to find
@@ -75,22 +75,22 @@ def makefile(target=None, action=None, filepath=None, env={}):
         if len(makeargs) > 0:
             args.append(makeargs)
 
-    if action is 'build':
+    if action == 'build':
         def run():
             args.append('default')
             rc = os.spawnvp(os.P_WAIT, "make", args)
             return rc == 0
-    elif action is 'clean':
+    elif action == 'clean':
         def run():
             args.append('clean')
             rc = os.spawnvp(os.P_WAIT, "make", args)
             return rc == 0
-    elif action is 'run':
+    elif action == 'run':
         def run():
             args.append('run')
             rc = os.spawnvp(os.P_WAIT, "make", args)
             return rc == 0
-    elif action is 'debug':
+    elif action == 'debug':
         def run():
             args.append('debug')
             rc = os.spawnvp(os.P_WAIT, "make", args)
@@ -110,7 +110,7 @@ def makefile(target=None, action=None, filepath=None, env={}):
                 # Error
                 return False
     else:
-        raise ValueError, "invalid action"
+        raise ValueError("invalid action")
 
     # Pass the target as the second argument
     if target: args.append(target)
@@ -121,13 +121,13 @@ def makefile(target=None, action=None, filepath=None, env={}):
         args.append(filepath)
 
     # Pass variables
-    for (k,v) in env.iteritems():
+    for (k,v) in env.items():
         args.append(k + "=" + v)
 
     # Print a status message, if running in verbose mode
     if globals.verbose:
 
-        print "Running '" + " ".join(args) + "' in " + os.getcwd()
+        print("Running '" + " ".join(args) + "' in " + os.getcwd())
 
     # Run the makefile and return result info
     return run()
@@ -141,11 +141,11 @@ def spawnwaitv(prog, args):
 
     # Print a status message if running in verbose mode
     if globals.verbose:
-        print "Running '" + " ".join(args) + "' in " + os.getcwd()
+        print("Running '" + " ".join(args) + "' in " + os.getcwd())
 
     # Check that the program is runnable
     if not os.access(prog, os.X_OK):
-        raise OSError, "Cannot execute '" + prog + "'"
+        raise OSError("Cannot execute '" + prog + "'")
 
     # Run the program
     return os.spawnve(os.P_WAIT, prog, args, env)

--- a/src/cuda/parboil/driver/text.py
+++ b/src/cuda/parboil/driver/text.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-from itertools import imap
 import re
 
 TOKEN = re.compile(r"(?:^|(?<=\s))[^\s]+|(?:^|(?<!\s))[\s]+")


### PR DESCRIPTION
## Summary
- Add GPGPU-Sim detection in gpuConfig.h by checking for `gpgpusim.config` file and parsing L2 cache parameters from it
- Update parboil driver from Python 2 to Python 3 (relative imports, print functions, exception syntax, itertools/dict updates)

## Test plan
- [x] Test microbenchmarks with GPGPU-Sim to verify L2 config parsing works correctly
- [x] Test microbenchmarks on real hardware to verify existing behavior is preserved
- [x] Run parboil benchmarks with Python 3 to verify driver migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)