### PR TITLE
Add separate GMMA microbenchmark build target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -110,6 +110,11 @@ GPU_Microbenchmark:
 	$(SETENV) $(MAKE) $(MAKE_ARGS) -C cuda/GPU_Microbenchmark
 	mv cuda/GPU_Microbenchmark/bin/* $(BINDIR)/$(BINSUBDIR)/
 
+GPU_Microbenchmark_gmma:
+	mkdir -p $(BINDIR)/$(BINSUBDIR)/
+	$(SETENV) $(MAKE) $(MAKE_ARGS) -C cuda/GPU_Microbenchmark gmma
+	mv cuda/GPU_Microbenchmark/bin/* $(BINDIR)/$(BINSUBDIR)/
+
 
 Deepbench_nvidia:
 	$(SETENV) $(MAKE) $(MAKE_ARGS) -C cuda/DeepBench/code/nvidia

--- a/src/cuda/GPU_Microbenchmark/Makefile
+++ b/src/cuda/GPU_Microbenchmark/Makefile
@@ -1,12 +1,18 @@
 BASE_DIR := $(shell pwd)
 BIN_DIR := $(BASE_DIR)/bin
-SUB_DIRS        = $(wildcard ubench/*/*/)
+ALL_SUB_DIRS    = $(wildcard ubench/*/*/)
+GMMA_DIRS       = $(filter %gmma/,$(ALL_SUB_DIRS))
+SUB_DIRS        = $(filter-out $(GMMA_DIRS),$(ALL_SUB_DIRS))
 SUB_DIRS_ALL    = $(SUB_DIRS:%=all-%)
 SUB_DIRS_CLEAN  = $(SUB_DIRS:%=clean-%)
+GMMA_DIRS_ALL   = $(GMMA_DIRS:%=all-%)
+GMMA_DIRS_CLEAN = $(GMMA_DIRS:%=clean-%)
 
 
 all: create_dir $(SUB_DIRS_ALL)
+gmma: create_dir $(GMMA_DIRS_ALL)
 clean: delete_dir $(SUB_DIRS_CLEAN)
+clean_gmma: $(GMMA_DIRS_CLEAN)
 
 $(SUB_DIRS_ALL):
 	$(MAKE) $(MAKE_FLAGS) -C $(@:all-%=%)


### PR DESCRIPTION
## Summary
- Filter GMMA directories out of the default GPU_Microbenchmark build so they don't break standard compilation
- Add dedicated `gmma` / `GPU_Microbenchmark_gmma` Make targets to compile GMMA benchmarks independently
- Add corresponding `clean_gmma` target for cleanup

## Test plan
- [ ] Run `make GPU_Microbenchmark` and verify GMMA directories are excluded
- [ ] Run `make GPU_Microbenchmark_gmma` and verify only GMMA benchmarks are built
- [ ] Verify `make clean` in GPU_Microbenchmark still works for non-GMMA targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)