### PR TITLE
Add RTX 3060 Laptop hw_def; fix CLK_FREQUENCY macro collision

### DIFF
--- a/src/cuda/GPU_Microbenchmark/hw_def/ampere_A100_hw_def.h
+++ b/src/cuda/GPU_Microbenchmark/hw_def/ampere_A100_hw_def.h
@@ -12,7 +12,10 @@
 
 #define L1_SIZE (192 * 1024) // Max L1 size in bytes
 
-#define CLK_FREQUENCY 1410 // frequency in MHz
+// NOTE: Frequency commented out since gpuConfig.h defines a `config` struct
+// with a member also named CLK_FREQUENCY, so `#define CLK_FREQUENCY` collides
+
+// #define CLK_FREQUENCY 1410 // frequency in MHz
 
 #define ISSUE_MODEL issue_model::single // single issue core or dual issue
 #define CORE_MODEL core_model::subcore  // subcore model or shared model

--- a/src/cuda/GPU_Microbenchmark/hw_def/ampere_RTX3060_MOBILE_hw_def.h
+++ b/src/cuda/GPU_Microbenchmark/hw_def/ampere_RTX3060_MOBILE_hw_def.h
@@ -1,10 +1,11 @@
 // These are the configration parameters that can be found publicly
-// Volta QV100 HW def file (sm_70)
-// Data source:
-// https://images.nvidia.com/content/volta-architecture/pdf/volta-architecture-whitepaper.pdf
+// Sources:
+// https://www.nvidia.com/content/dam/en-zz/Solutions/geforce/ampere/pdf/NVIDIA-ampere-GA102-GPU-Architecture-Whitepaper-V1.pdf
+// https://en.wikipedia.org/wiki/GeForce_30_series
+// https://en.wikipedia.org/wiki/CUDA
 
-#ifndef VOLTA_QV100_HW_DEF_H
-#define VOLTA_QV100_HW_DEF_H
+#ifndef AMPERE_RTX3060_DEF_H
+#define AMPERE_RTX3060_DEF_H
 
 #include "./common/common.h"
 #include "./common/deviceQuery.h"
@@ -16,15 +17,15 @@
 
 // #define CLK_FREQUENCY 1132 // frequency in MHz
 
-#define ISSUE_MODEL issue_model::single
-#define CORE_MODEL core_model::subcore
-#define DRAM_MODEL dram_model::HBM
-#define WARP_SCHEDS_PER_SM 4
+#define ISSUE_MODEL issue_model::single // single issue core or dual issue
+#define CORE_MODEL core_model::subcore  // subcore model or shared model
+#define DRAM_MODEL dram_model::GDDR6    // memory type
+#define WARP_SCHEDS_PER_SM 4            // number of warp schedulers per SM
 
+// number of SASS HMMA per 16x16 PTX WMMA for FP16 - FP32 accumlate operation
 // see slide 22 at
 // https://developer.download.nvidia.com/video/gputechconf/gtc/2020/presentations/s21730-inside-the-nvidia-ampere-architecture.pdf
-// number of SASS HMMA per 16x16 PTX WMMA for FP16 operands - FP32  accumlate operation
-#define SASS_hmma_per_PTX_wmma 16
+#define SASS_hmma_per_PTX_wmma 2
 
 // These vars are almost constant between HW generation
 // see slide 24 from Nvidia at

--- a/src/cuda/GPU_Microbenchmark/hw_def/ampere_RTX3070_hw_def.h
+++ b/src/cuda/GPU_Microbenchmark/hw_def/ampere_RTX3070_hw_def.h
@@ -12,7 +12,10 @@
 
 #define L1_SIZE (128 * 1024) // Max L1 size in bytes
 
-#define CLK_FREQUENCY 1132 // frequency in MHz
+// NOTE: Frequency commented out since gpuConfig.h defines a `config` struct
+// with a member also named CLK_FREQUENCY, so `#define CLK_FREQUENCY` collides
+
+// #define CLK_FREQUENCY 1132 // frequency in MHz
 
 #define ISSUE_MODEL issue_model::single // single issue core or dual issue
 #define CORE_MODEL core_model::subcore  // subcore model or shared model

--- a/src/cuda/GPU_Microbenchmark/hw_def/blackwell_B200_hw_def.h
+++ b/src/cuda/GPU_Microbenchmark/hw_def/blackwell_B200_hw_def.h
@@ -8,6 +8,9 @@
 
 #define L1_SIZE (256 * 1024) // Max L1 size in bytes
 
+// NOTE: Frequency commented out since gpuConfig.h defines a `config` struct
+// with a member also named CLK_FREQUENCY, so `#define CLK_FREQUENCY` collides
+
 // #define CLK_FREQUENCY 1665 // frequency in MHz
 
 #define ISSUE_MODEL issue_model::single // single issue core or dual issue

--- a/src/cuda/GPU_Microbenchmark/hw_def/hopper_H100_hw_def.h
+++ b/src/cuda/GPU_Microbenchmark/hw_def/hopper_H100_hw_def.h
@@ -11,7 +11,10 @@
 
 #define L1_SIZE (256 * 1024) // Max L1 size in bytes
 
-#define CLK_FREQUENCY 1455 // frequency in MHz
+// NOTE: Frequency commented out since gpuConfig.h defines a `config` struct
+// with a member also named CLK_FREQUENCY, so `#define CLK_FREQUENCY` collides
+
+// #define CLK_FREQUENCY 1455 // frequency in MHz
 
 #define ISSUE_MODEL issue_model::single
 #define CORE_MODEL core_model::subcore

--- a/src/cuda/GPU_Microbenchmark/hw_def/hw_def.h
+++ b/src/cuda/GPU_Microbenchmark/hw_def/hw_def.h
@@ -11,9 +11,12 @@
 
 //#include "ampere_RTX3070_hw_def.h"
 
-// #include "volta_TITANV_hw_def.h"
+#include "ampere_RTX3060_MOBILE_hw_def.h"
 
-// #include "ampere_A100_hw_def.h"
-#include "blackwell_B200_hw_def.h"
+//#include "volta_TITANV_hw_def.h"
+
+//#include "ampere_A100_hw_def.h"
+
+//#include "blackwell_B200_hw_def.h"
 
 #endif

--- a/src/cuda/GPU_Microbenchmark/hw_def/kepler_TITAN_hw_def.h
+++ b/src/cuda/GPU_Microbenchmark/hw_def/kepler_TITAN_hw_def.h
@@ -7,7 +7,10 @@
 
 #define L1_SIZE (64 * 1024) // Max L1 size in bytes, when enabled
 
-#define CLK_FREQUENCY 837 // frequency in MHz
+// NOTE: Frequency commented out since gpuConfig.h defines a `config` struct
+// with a member also named CLK_FREQUENCY, so `#define CLK_FREQUENCY` collides
+
+// #define CLK_FREQUENCY 837 // frequency in MHz
 
 #define ISSUE_MODEL issue_model::dual
 #define CORE_MODEL core_model::shared

--- a/src/cuda/GPU_Microbenchmark/hw_def/pascal_TITANX_hw_def.h
+++ b/src/cuda/GPU_Microbenchmark/hw_def/pascal_TITANX_hw_def.h
@@ -7,7 +7,10 @@
 
 #define L1_SIZE (24 * 1024) // Max L1 size in bytes, when enabled
 
-#define CLK_FREQUENCY 1417 // frequency in MHz
+// NOTE: Frequency commented out since gpuConfig.h defines a `config` struct
+// with a member also named CLK_FREQUENCY, so `#define CLK_FREQUENCY` collides
+
+//#define CLK_FREQUENCY 1417 // frequency in MHz
 
 #define ISSUE_MODEL issue_model::dual
 #define CORE_MODEL core_model::subcore

--- a/src/cuda/GPU_Microbenchmark/hw_def/turing_RTX2060_hw_def.h
+++ b/src/cuda/GPU_Microbenchmark/hw_def/turing_RTX2060_hw_def.h
@@ -8,7 +8,10 @@
 
 #define L1_SIZE (64 * 1024) // Max L1 size in bytes
 
-#define CLK_FREQUENCY 1365 // frequency in MHz
+// NOTE: Frequency commented out since gpuConfig.h defines a `config` struct
+// with a member also named CLK_FREQUENCY, so `#define CLK_FREQUENCY` collides
+
+// #define CLK_FREQUENCY 1365 // frequency in MHz
 
 #define ISSUE_MODEL issue_model::single   // single issue core or dual issue
 #define CORE_MODEL core_model::subcore    // subcore model or shared model

--- a/src/cuda/GPU_Microbenchmark/hw_def/volta_TITANV_hw_def.h
+++ b/src/cuda/GPU_Microbenchmark/hw_def/volta_TITANV_hw_def.h
@@ -11,7 +11,10 @@
 
 #define L1_SIZE (128 * 1024) // Max L1 size in bytes
 
-#define CLK_FREQUENCY 1200 // frequency in MHz
+// NOTE: Frequency commented out since gpuConfig.h defines a `config` struct
+// with a member also named CLK_FREQUENCY, so `#define CLK_FREQUENCY` collides
+
+// #define CLK_FREQUENCY 1200 // frequency in MHz
 
 #define ISSUE_MODEL issue_model::single
 #define CORE_MODEL core_model::subcore

--- a/src/cuda/GPU_Microbenchmark/hw_def/volta_V100_hw_def.h
+++ b/src/cuda/GPU_Microbenchmark/hw_def/volta_V100_hw_def.h
@@ -11,7 +11,10 @@
 
 #define L1_SIZE (128 * 1024) // Max L1 size in bytes
 
-#define CLK_FREQUENCY 1455 // frequency in MHz
+// NOTE: Frequency commented out since gpuConfig.h defines a `config` struct
+// with a member also named CLK_FREQUENCY, so `#define CLK_FREQUENCY` collides
+
+// #define CLK_FREQUENCY 1455 // frequency in MHz
 
 #define ISSUE_MODEL issue_model::single
 #define CORE_MODEL core_model::subcore


### PR DESCRIPTION
## Summary

Adds an hw_def header for the RTX 3060 Laptop GPU so the GPU_Microbenchmark suite can target it, and fixes a build-breaking macro collision that affects every existing hw_def header on modern toolchains.

## Motivation / root cause

 Each `*_hw_def.h` does `#define CLK_FREQUENCY <MHz>`. `hw_def/common/gpuConfig.h` defines a gpuConfig struct with a member also spelled `CLK_FREQUENCY`, so the macro rewrites the member name and the tuner fails to compile:
 
<img width="760" height="456" alt="image" src="https://github.com/user-attachments/assets/c23c4242-dec7-42d5-a31b-a27edaa40015" />


`error: expected identifier before numeric constant   (CLK_FREQUENCY -> 1410)`

I found this bug by looking at the default config (Blackwell B200 -> the `CLK_FREQUENCY` is commented out)

## Changes

`ampere_RTX3060_MOBILE_hw_def.h`: GA106 specs (30 SM, 1536 thr/SM, 128 KB L1, 3 MB L2, 192-bit, cap 8.6).
`hw_def.h`: activate the RTX3060 include.
All sibling `*_hw_def.h`: comment out #define CLK_FREQUENCY with a reviewer note

## Evidence (before / after)

<!-- The single most important section for anything claiming to fix a bug
or improve accuracy. Reviewers should not have to run your fix to believe
it works — show them.

- Before: exact error/output, or a stats table/CSV showing the broken state
- After: same command, same corpus, showing the fix
- If numeric (correlation, MAPE, cycle counts): a before/after table beats
  a paragraph -->

*Before:* `#define CLK_FREQUENCY 1410` → compile error above

*After:* header set builds; `config_int`/`config` report the real card (30 SM, cap 8.6)

## Test plan

<!-- Concrete, runnable, checked off before you open the PR — not aspirational.
Include exact commands so a reviewer can reproduce your result, not just
your conclusion. -->

- [ ] `make -C src/cuda/GPU_Microbenchmark builds the RTX3060 target`
- [ ] a config ubench prints correct SM/cap for the card